### PR TITLE
Install package locally for read-the-docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,8 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
+


### PR DESCRIPTION
read-the-docs needs the package to be installed so that autodoc can
find the modules it is documenting