### PR TITLE
use setuptools_scm to manage version numbers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+prune .github
+exclude .gitignore
+exclude .readthedocs.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 prune .github
 exclude .gitignore
 exclude .readthedocs.yml
+exclude .travis.yml

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ EXTRAS_REQUIRE = {
 
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 
+SETUP_REQUIRES = ['setuptools_scm']
+
 CLASSIFIERS = [
     'Development Status :: 2 - Pre-Alpha',
     'Operating System :: OS Independent',
@@ -59,11 +61,12 @@ PACKAGES = ['pvanalytics']
 
 setup(
     name=DISTNAME,
-    version="0.0.1",
+    use_scm_version=True,
     packages=PACKAGES,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     tests_require=TESTS_REQUIRE,
+    setup_requires=SETUP_REQUIRES,
     ext_modules=[],
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Closes #12 

@wholmgren pointed out that versioneer is no longer maintained. setuptools_scm achieves the same automatic version number management and is very easy to use. It also does not require committing extra files to the repo. Seems like a win-win to me.