### PR TITLE
Use travis for uploading coverage reports to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+if: type = pull_request
+
+install:
+  - pip install -r requirements.txt
+  - pip install pytest pytest-cov coveralls
+
+script:
+  - pytest --cov=pvanalytics --cov-report term-missing
+
+after_success:
+  - coveralls


### PR DESCRIPTION
Github actions do not expose secrets for PRs from forks. This means that in order to upload coverage reports for PRs from a github action we would have to expose the REPO_TOKEN. As a work around we  can build on travis for PRs and upload to coveralls from there.