### PR TITLE
Make check_limits quality function public

### DIFF
--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -3,6 +3,8 @@
 import numpy as np
 from pvlib.tools import cosd
 
+from pvanalytics.quality import util
+
 
 QCRAD_LIMITS = {'ghi_ub': {'mult': 1.5, 'exp': 1.2, 'min': 100},
                 'dhi_ub': {'mult': 0.95, 'exp': 1.2, 'min': 50},
@@ -28,27 +30,6 @@ QCRAD_CONSISTENCY = {
             'zenith_bounds': [75, 93],
             'ghi_bounds': [50, np.Inf],
             'ratio_bounds': [0.0, 1.10]}}}
-
-
-def _check_limits(val, lb=None, ub=None, lb_ge=False, ub_le=False):
-    """Return True where lb < (or <=) val < (or <=) ub."""
-    if lb_ge:
-        lb_op = np.greater_equal
-    else:
-        lb_op = np.greater
-    if ub_le:
-        ub_op = np.less_equal
-    else:
-        ub_op = np.less
-
-    if (lb is not None) & (ub is not None):
-        return lb_op(val, lb) & ub_op(val, ub)
-    elif lb is not None:
-        return lb_op(val, lb)
-    elif ub is not None:
-        return ub_op(val, ub)
-    else:
-        raise ValueError('must provide either upper or lower bound')
 
 
 def _qcrad_ub(dni_extra, sza, lim):
@@ -90,7 +71,7 @@ def check_ghi_limits_qcrad(ghi, solar_zenith, dni_extra, limits=None):
         limits = QCRAD_LIMITS
     ghi_ub = _qcrad_ub(dni_extra, solar_zenith, limits['ghi_ub'])
 
-    ghi_limit_flag = _check_limits(ghi, limits['ghi_lb'], ghi_ub)
+    ghi_limit_flag = util.check_limits(ghi, limits['ghi_lb'], ghi_ub)
 
     return ghi_limit_flag
 
@@ -129,7 +110,7 @@ def check_dhi_limits_qcrad(dhi, solar_zenith, dni_extra, limits=None):
 
     dhi_ub = _qcrad_ub(dni_extra, solar_zenith, limits['dhi_ub'])
 
-    dhi_limit_flag = _check_limits(dhi, limits['dhi_lb'], dhi_ub)
+    dhi_limit_flag = util.check_limits(dhi, limits['dhi_lb'], dhi_ub)
 
     return dhi_limit_flag
 
@@ -168,7 +149,7 @@ def check_dni_limits_qcrad(dni, solar_zenith, dni_extra, limits=None):
 
     dni_ub = _qcrad_ub(dni_extra, solar_zenith, limits['dni_ub'])
 
-    dni_limit_flag = _check_limits(dni, limits['dni_lb'], dni_ub)
+    dni_limit_flag = util.check_limits(dni, limits['dni_lb'], dni_ub)
 
     return dni_limit_flag
 
@@ -254,10 +235,10 @@ def _get_bounds(bounds):
 def _check_irrad_ratio(ratio, ghi, sza, bounds):
     # unpack bounds dict
     ghi_lb, ghi_ub, sza_lb, sza_ub, ratio_lb, ratio_ub = _get_bounds(bounds)
-    # for zenith set lb_ge to handle edge cases, e.g., zenith=0
-    return ((_check_limits(sza, lb=sza_lb, ub=sza_ub, lb_ge=True))
-            & (_check_limits(ghi, lb=ghi_lb, ub=ghi_ub))
-            & (_check_limits(ratio, lb=ratio_lb, ub=ratio_ub)))
+    # for zenith set inclusive_lower to handle edge cases, e.g., zenith=0
+    return ((util.check_limits(sza, lower_bound=sza_lb, upper_bound=sza_ub, inclusive_lower=True))
+            & (util.check_limits(ghi, lower_bound=ghi_lb, upper_bound=ghi_ub))
+            & (util.check_limits(ratio, lower_bound=ratio_lb, upper_bound=ratio_ub)))
 
 
 def check_irradiance_consistency_qcrad(ghi, solar_zenith, dni_extra, dhi, dni,

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -236,9 +236,12 @@ def _check_irrad_ratio(ratio, ghi, sza, bounds):
     # unpack bounds dict
     ghi_lb, ghi_ub, sza_lb, sza_ub, ratio_lb, ratio_ub = _get_bounds(bounds)
     # for zenith set inclusive_lower to handle edge cases, e.g., zenith=0
-    return ((util.check_limits(sza, lower_bound=sza_lb, upper_bound=sza_ub, inclusive_lower=True))
-            & (util.check_limits(ghi, lower_bound=ghi_lb, upper_bound=ghi_ub))
-            & (util.check_limits(ratio, lower_bound=ratio_lb, upper_bound=ratio_ub)))
+    return (
+        util.check_limits(sza, lower_bound=sza_lb,
+                          upper_bound=sza_ub, inclusive_lower=True)
+        & util.check_limits(ghi, lower_bound=ghi_lb, upper_bound=ghi_ub)
+        & util.check_limits(ratio, lower_bound=ratio_lb, upper_bound=ratio_ub)
+    )
 
 
 def check_irradiance_consistency_qcrad(ghi, solar_zenith, dni_extra, dhi, dni,

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -1,0 +1,51 @@
+"""General-purpose quality control utility functions."""
+import numpy as np
+
+
+def check_limits(val, lower_bound=None, upper_bound=None,
+                 inclusive_lower=False, inclusive_upper=False):
+    """Check whether a value falls withing the given limits.
+
+    At least one of `lower_bound` or `upper_bound` must be provided.
+
+    Parameters
+    ----------
+    val : array_like
+        Values to test.
+    lower_bound : float, default None
+        Lower limit.
+    upper_bound : float, default None
+        Upper limit.
+    inclusive_lower : bool, default False
+        Whether the lower bound is inclusive (`val` >= `lower_bound`).
+    inclusive_upper : bool, default False
+        Whether the upper bound is inclusive (`val` <= `upper_bound`).
+
+    Returns
+    -------
+    array_like
+        True for every value in `val` that is between `lower_bound`
+        and `upper_bound`.
+
+    Raises
+    ------
+    ValueError
+        if `lower_bound` nor `upper_bound` is provided.
+    """
+    if inclusive_lower:
+        lb_op = np.greater_equal
+    else:
+        lb_op = np.greater
+    if inclusive_upper:
+        ub_op = np.less_equal
+    else:
+        ub_op = np.less
+
+    if (lower_bound is not None) & (upper_bound is not None):
+        return lb_op(val, lower_bound) & ub_op(val, upper_bound)
+    elif lower_bound is not None:
+        return lb_op(val, lower_bound)
+    elif upper_bound is not None:
+        return ub_op(val, upper_bound)
+    else:
+        raise ValueError('must provide either upper or lower bound')

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -99,28 +99,3 @@ def test_check_irradiance_consistency_qcrad(irradiance_qcrad):
                         check_names=False)
     assert_series_equal(diffuse, expected['diffuse_ratio_limit'],
                         check_names=False)
-
-
-def test_check_limits():
-    """Test the private check limits function."""
-    expected = pd.Series(data=[True, False])
-    data = pd.Series(data=[3, 2])
-    result = irradiance._check_limits(val=data, lb=2.5)
-    assert_series_equal(expected, result, check_names=False)
-    result = irradiance._check_limits(val=data, lb=3, lb_ge=True)
-    assert_series_equal(expected, result, check_names=False)
-
-    data = pd.Series(data=[3, 4])
-    result = irradiance._check_limits(val=data, ub=3.5)
-    assert_series_equal(expected, result, check_names=False)
-    result = irradiance._check_limits(val=data, ub=3, ub_le=True)
-    assert_series_equal(expected, result, check_names=False)
-
-    result = irradiance._check_limits(val=data, lb=3, ub=4, lb_ge=True,
-                                      ub_le=True)
-    assert all(result)
-    result = irradiance._check_limits(val=data, lb=3, ub=4)
-    assert not any(result)
-
-    with pytest.raises(ValueError):
-        irradiance._check_limits(val=data)

--- a/pvanalytics/tests/quality/test_util.py
+++ b/pvanalytics/tests/quality/test_util.py
@@ -20,8 +20,13 @@ def test_check_limits():
     result = util.check_limits(val=data, upper_bound=3, inclusive_upper=True)
     assert_series_equal(expected, result, check_names=False)
 
-    result = util.check_limits(val=data, lower_bound=3, upper_bound=4, inclusive_lower=True,
-                                      inclusive_upper=True)
+    result = util.check_limits(
+        val=data,
+        lower_bound=3,
+        upper_bound=4,
+        inclusive_lower=True,
+        inclusive_upper=True
+    )
     assert all(result)
     result = util.check_limits(val=data, lower_bound=3, upper_bound=4)
     assert not any(result)

--- a/pvanalytics/tests/quality/test_util.py
+++ b/pvanalytics/tests/quality/test_util.py
@@ -1,0 +1,30 @@
+"""Tests for utility functions."""
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+import pytest
+from pvanalytics.quality import util
+
+
+def test_check_limits():
+    """Test the private check limits function."""
+    expected = pd.Series(data=[True, False])
+    data = pd.Series(data=[3, 2])
+    result = util.check_limits(val=data, lower_bound=2.5)
+    assert_series_equal(expected, result, check_names=False)
+    result = util.check_limits(val=data, lower_bound=3, inclusive_lower=True)
+    assert_series_equal(expected, result, check_names=False)
+
+    data = pd.Series(data=[3, 4])
+    result = util.check_limits(val=data, upper_bound=3.5)
+    assert_series_equal(expected, result, check_names=False)
+    result = util.check_limits(val=data, upper_bound=3, inclusive_upper=True)
+    assert_series_equal(expected, result, check_names=False)
+
+    result = util.check_limits(val=data, lower_bound=3, upper_bound=4, inclusive_lower=True,
+                                      inclusive_upper=True)
+    assert all(result)
+    result = util.check_limits(val=data, lower_bound=3, upper_bound=4)
+    assert not any(result)
+
+    with pytest.raises(ValueError):
+        util.check_limits(val=data)


### PR DESCRIPTION
This is a useful function for many QA tasks. Having it in a publicly accessible module will not only allow users to write their own limit-based quality tests, but will let us use it in quality tests in other modules.