### PR TITLE
Port weather data validation checks from SolarForecastArbiter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,18 @@ spacing, time-shifts, and time zone validation.
 
    quality.time.spacing
 
+Weather
+-------
+
+Quality checks for weather data.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.weather.relative_humidity_limits
+   quality.weather.temperature_limits
+   quality.weather.wind_limits
+
 Features
 ========
 

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -36,5 +36,13 @@ the terms of the MIT License
   :py:func:`pvanalytics.quality.gaps.interpolation()` and
   :py:func:`pvanalytics.quality.gaps.stale_values()`
 
+* Weather related quality functions
+
+  * :py:func:`pvanalytics.quality.weather.temperature_limits`
+
+  * :py:func:`pvanalytics.quality.weather.relative_humidity_limits`
+
+  * :py:func:`pvanalytics.quality.weather.wind_limits`
+
 * Level-based clipping detection in
   :py:func:`pvanalytics.features.clipping_levels`.

--- a/pvanalytics/quality/weather.py
+++ b/pvanalytics/quality/weather.py
@@ -22,3 +22,29 @@ def temperature_limits(air_temperature, limits=(-35.0, 50.0)):
     return util.check_limits(
         air_temperature, lower_bound=limits[0], upper_bound=limits[1]
     )
+
+
+def relative_humidity_limits(relative_humidity, limits=(0, 100)):
+    """Check for extremes in relative humidity data.
+
+    Parameters
+    ----------
+    relative_humidity : Series
+        Relative humidity in %.
+    limits : tuple, default (0, 100)
+        (lower bound, upper bound) for relative humidity.
+
+    Returns
+    -------
+    Series
+        True if `relative_humidity` >= lower bound and
+        `relative_humidity` <= upper_bound.
+
+    """
+    return util.check_limits(
+        relative_humidity,
+        lower_bound=limits[0],
+        upper_bound=limits[1],
+        inclusive_lower=True,
+        inclusive_upper=True
+    )

--- a/pvanalytics/quality/weather.py
+++ b/pvanalytics/quality/weather.py
@@ -1,1 +1,24 @@
 """Quality control functions for weather data."""
+from pvanalytics.quality import util
+
+
+def temperature_limits(air_temperature, limits=(-35.0, 50.0)):
+    """Identify extreme temperatures.
+
+    Parameters
+    ----------
+    air_temperature : Series
+        Air temperature in Celsius.
+    temp_limits : tuple, default (-35, 50)
+        (lower bound, upper bound) for temperature.
+
+    Returns
+    -------
+    Series
+        True if `air_temperature` > lower bound and `air_temperature`
+        < upper bound.
+
+    """
+    return util.check_limits(
+        air_temperature, lower_bound=limits[0], upper_bound=limits[1]
+    )

--- a/pvanalytics/quality/weather.py
+++ b/pvanalytics/quality/weather.py
@@ -48,3 +48,28 @@ def relative_humidity_limits(relative_humidity, limits=(0, 100)):
         inclusive_lower=True,
         inclusive_upper=True
     )
+
+
+def wind_limits(wind_speed, limits=(0.0, 50.0)):
+    """Check for extreme wind speeds.
+
+    Parameters
+    ----------
+    wind_speed : Series
+        Wind speed in :math:`m/s`
+    wind_limits : tuple, default (0, 50)
+        (lower bound, upper bound) for wind speed.
+
+    Returns
+    -------
+    Series
+        True if `wind_speed` >= lower bound and `wind_speed` < upper
+        bound.
+
+    """
+    return util.check_limits(
+        wind_speed,
+        lower_bound=limits[0],
+        upper_bound=limits[1],
+        inclusive_lower=True
+    )

--- a/pvanalytics/quality/weather.py
+++ b/pvanalytics/quality/weather.py
@@ -8,7 +8,7 @@ def temperature_limits(air_temperature, limits=(-35.0, 50.0)):
     Parameters
     ----------
     air_temperature : Series
-        Air temperature in Celsius.
+        Air temperature [C].
     temp_limits : tuple, default (-35, 50)
         (lower bound, upper bound) for temperature.
 

--- a/pvanalytics/quality/weather.py
+++ b/pvanalytics/quality/weather.py
@@ -3,7 +3,7 @@ from pvanalytics.quality import util
 
 
 def temperature_limits(air_temperature, limits=(-35.0, 50.0)):
-    """Identify extreme temperatures.
+    """Identify temperature values that are within limits.
 
     Parameters
     ----------
@@ -25,7 +25,7 @@ def temperature_limits(air_temperature, limits=(-35.0, 50.0)):
 
 
 def relative_humidity_limits(relative_humidity, limits=(0, 100)):
-    """Check for extremes in relative humidity data.
+    """Identify relative humidity values that are within limits.
 
     Parameters
     ----------
@@ -51,7 +51,7 @@ def relative_humidity_limits(relative_humidity, limits=(0, 100)):
 
 
 def wind_limits(wind_speed, limits=(0.0, 50.0)):
-    """Check for extreme wind speeds.
+    """Identify wind speed values that are within limits.
 
     Parameters
     ----------

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -1,0 +1,31 @@
+"""Tests for functions in quality.weather"""
+import pytest
+import pandas as pd
+import numpy as np
+from pandas.util.testing import assert_series_equal
+from pvanalytics.quality import weather
+
+
+@pytest.fixture
+def weather_data():
+    """Weather data for use in tests."""
+    output = pd.DataFrame(columns=['air_temperature', 'wind_speed',
+                                   'relative_humidity',
+                                   'extreme_temp_flag', 'extreme_wind_flag',
+                                   'extreme_rh_flag'],
+                          data=np.array([[-40, -5, -5, 0, 0, 0],
+                                         [10, 10, 50, 1, 1, 1],
+                                         [140, 55, 105, 0, 0, 0]]))
+    dtypes = ['float64', 'float64', 'float64', 'bool', 'bool', 'bool']
+    for (col, typ) in zip(output.columns, dtypes):
+        output[col] = output[col].astype(typ)
+    return output
+
+
+def test_check_temperature_limits(weather_data):
+    """Check that temperature values beyond limits are flagged."""
+    assert_series_equal(
+        weather.temperature_limits(weather_data['air_temperature']),
+        weather_data['extreme_temp_flag'],
+        check_names=False
+    )

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -29,3 +29,12 @@ def test_check_temperature_limits(weather_data):
         weather_data['extreme_temp_flag'],
         check_names=False
     )
+
+
+def test_relative_humidity_limits(weather_data):
+    """Check that relative humidity values outside normal range are flagged."""
+    assert_series_equal(
+        weather.relative_humidity_limits(weather_data['relative_humidity']),
+        weather_data['extreme_rh_flag'],
+        check_names=False
+    )

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -38,3 +38,12 @@ def test_relative_humidity_limits(weather_data):
         weather_data['extreme_rh_flag'],
         check_names=False
     )
+
+
+def test_wind_limits(weather_data):
+    """Check that extremes in wind data are flagged."""
+    assert_series_equal(
+        weather.wind_limits(weather_data['wind_speed']),
+        weather_data['extreme_wind_flag'],
+        check_names=False
+    )


### PR DESCRIPTION
Extreme value filters for air temperature, relative humidity, and wind speed ported from SolarForecastArbiter (SFA). These functions just wrap `quality.util.check_limits()` providing reasonable defaults for each type of data.

## Changes from SFA

* remove `@mask_flags` decorator
* the name of the returned Boolean series is not set.
* rename `validator.check_temperature_limits()` to `weather.temperature_limits()`
* rename `validator.check_rh_limits()` to `weather.relative_humidity_limits()`
* rename `validator.check_wind_limits()` to `weather.wind_limits()`