### PR TITLE
Port clearsky-based quality checks from Solar Forecast Arbiter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,8 +40,7 @@ eliminate data that is unrealistically high.
 .. autosummary::
    :toctree: generated/
 
-   quality.irradiance.ghi_clearsky_limits
-   quality.irradiance.poa_clearsky_limits
+   quality.irradiance.clearsky_limits
 
 Gaps
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,15 @@ Irradiance measurements can also be checked for consistency.
 
    quality.irradiance.check_irradiance_consistency_qcrad
 
+GHI and POA irradiance can be validated against clearsky values to
+eliminate data that is unrealistically high.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.irradiance.ghi_clearsky_limits
+   quality.irradiance.poa_clearsky_limits
+
 Gaps
 ----
 

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -35,3 +35,6 @@ the terms of the MIT License
 * The interpolation and stuck value detection functions
   :py:func:`pvanalytics.quality.gaps.interpolation()` and
   :py:func:`pvanalytics.quality.gaps.stale_values()`
+
+* The clearsky limits quality check
+  :py:func:`pvanalytics.quality.irradiance.clearsky_limits`

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -313,12 +313,12 @@ def check_irradiance_consistency_qcrad(ghi, solar_zenith, dhi, dni,
 
 
 def clearsky_limits(measured, clearsky, csi_max=1.1):
-    """Identify irradiance measurements greater than clearsky values.
+    """Identify irradiance values which do not exceed clearsky values.
 
     Uses :py:func:`pvlib.irradiance.clearsky_index` to compute the
-    clearsky index for `measured` and `clearsky`. Compares the
+    clearsky index as the ratio of `measured` to `clearsky`. Compares the
     clearsky index to `csi_max` to identify values in `measured` that
-    are greater than the expected clearsky irradiance.
+    are less than or equal to `csi_max`.
 
     Parameters
     ----------

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -312,69 +312,33 @@ def check_irradiance_consistency_qcrad(ghi, solar_zenith, dhi, dni,
     return consistent_components, diffuse_ratio_limit
 
 
-def ghi_clearsky_limits(ghi, ghi_clearsky, csi_max=1.1):
-    """Identify GHI values greater than clearsky values.
+def clearsky_limits(measured, clearsky, csi_max=1.1):
+    """Identify irradiance measurements greater than clearsky values.
 
     Uses :py:func:`pvlib.irradiance.clearsky_index` to compute the
-    clearsky index for `ghi` and `ghi_clearsky`. Compares the
-    clearsky index to `csi_max` to identify values in `ghi` that are
-    greater than the expected clearsky irradiance.
+    clearsky index for `measured` and `clearsky`. Compares the
+    clearsky index to `csi_max` to identify values in `measured` that
+    are greater than the expected clearsky irradiance.
 
     Parameters
     ----------
-    ghi : Series
-        Global horizontal irradiance in :math:`W/m^2`
-    ghi_clearsky : Series
-        Global horizontal irradiance in :math:`W/m^2` under clearsky
-        conditions.
+    measured : Series
+        Measured irradiance in :math:`W/m^2`.
+    clearsky : Series
+        Expected clearsky irradiance in :math:`W/m^2`.
     csi_max : float, default 1.1
-        Maximum acceptable clearsky index. Any clearsky index value
-        greater than this indicates a `ghi` value that is too large.
+        Maximum ratio of `measured` to `clearsky` (clearsky index).
 
     Returns
     -------
     Series
-        True for each value where the clearsky index does not exceed
-        `csi_max`.
+        True for each value where the clearsky index is less than or
+        equal to `csi_max`.
 
     """
     csi = pvlib.irradiance.clearsky_index(
-        ghi,
-        ghi_clearsky,
-        max_clearsky_index=np.Inf
-    )
-    return util.check_limits(csi, upper_bound=csi_max, inclusive_upper=True)
-
-
-def poa_clearsky_limits(poa, poa_clearsky, csi_max=1.1):
-    """Identify POA irradiance values greater than clearsky values.
-
-    Uses :py:func:`pvlib.irradiance.clearsky_index` to compute the
-    clearsky index for `poa` and `poa_clearsky`. Compares the
-    clearsky index to `csi_max` to identify values in `poa` that are
-    greater than the expected clearsky irradiance.
-
-    Parameters
-    ----------
-    poa : Series
-        Plane of array irradiance in :math:`W/m^2`
-    poa_clearsky : Series
-        Plane of array irradiance in :math:`W/m^2` under clearsky
-        conditions.
-    csi_max : float, default 1.1
-        Maximum clearsky index that defines when POA irradiance exceeds
-        clear-sky value.
-
-    Returns
-    -------
-    Series
-        True for each value where the clearsky index does not exceed
-        `csi_max`.
-
-    """
-    csi = pvlib.irradiance.clearsky_index(
-        poa,
-        poa_clearsky,
+        measured,
+        clearsky,
         max_clearsky_index=np.Inf
     )
     return util.check_limits(csi, upper_bound=csi_max, inclusive_upper=True)

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from pvlib.tools import cosd
+import pvlib
 
 from pvanalytics.quality import util
 
@@ -309,3 +310,71 @@ def check_irradiance_consistency_qcrad(ghi, solar_zenith, dhi, dni,
                              bounds=bounds['low_zenith']))
 
     return consistent_components, diffuse_ratio_limit
+
+
+def ghi_clearsky_limits(ghi, ghi_clearsky, csi_max=1.1):
+    """Identify GHI values greater than clearsky values.
+
+    Uses :py:func:`pvlib.irradiance.clearsky_index` to compute the
+    clearsky index for `ghi` and `ghi_clearsky`. Compares the
+    clearsky index to `csi_max` to identify values in `ghi` that are
+    greater than the expected clearsky irradiance.
+
+    Parameters
+    ----------
+    ghi : Series
+        Global horizontal irradiance in :math:`W/m^2`
+    ghi_clearsky : Series
+        Global horizontal irradiance in :math:`W/m^2` under clearsky
+        conditions.
+    csi_max : float, default 1.1
+        Maximum acceptable clearsky index. Any clearsky index value
+        greater than this indicates a `ghi` value that is too large.
+
+    Returns
+    -------
+    Series
+        True for each value where the clearsky index does not exceed
+        `csi_max`.
+
+    """
+    csi = pvlib.irradiance.clearsky_index(
+        ghi,
+        ghi_clearsky,
+        max_clearsky_index=np.Inf
+    )
+    return util.check_limits(csi, upper_bound=csi_max, inclusive_upper=True)
+
+
+def poa_clearsky_limits(poa, poa_clearsky, csi_max=1.1):
+    """Identify POA irradiance values greater than clearsky values.
+
+    Uses :py:func:`pvlib.irradiance.clearsky_index` to compute the
+    clearsky index for `poa` and `poa_clearsky`. Compares the
+    clearsky index to `csi_max` to identify values in `poa` that are
+    greater than the expected clearsky irradiance.
+
+    Parameters
+    ----------
+    poa : Series
+        Plane of array irradiance in :math:`W/m^2`
+    poa_clearsky : Series
+        Plane of array irradiance in :math:`W/m^2` under clearsky
+        conditions.
+    csi_max : float, default 1.1
+        Maximum clearsky index that defines when POA irradiance exceeds
+        clear-sky value.
+
+    Returns
+    -------
+    Series
+        True for each value where the clearsky index does not exceed
+        `csi_max`.
+
+    """
+    csi = pvlib.irradiance.clearsky_index(
+        poa,
+        poa_clearsky,
+        max_clearsky_index=np.Inf
+    )
+    return util.check_limits(csi, upper_bound=csi_max, inclusive_upper=True)

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -1,6 +1,9 @@
 """Tests for irradiance quality control functions."""
+from datetime import datetime
+import pytz
 import pandas as pd
 import numpy as np
+from pvlib.location import Location
 
 import pytest
 from pandas.util.testing import assert_series_equal
@@ -99,3 +102,56 @@ def test_check_irradiance_consistency_qcrad(irradiance_qcrad):
                         check_names=False)
     assert_series_equal(diffuse, expected['diffuse_ratio_limit'],
                         check_names=False)
+
+
+@pytest.fixture
+def location():
+    """Fixture giving Albuquerque's location."""
+    return Location(
+        latitude=35.05,
+        longitude=-106.5,
+        altitude=1619,
+        name="Albuquerque",
+        tz="MST"
+    )
+
+
+@pytest.fixture
+def times():
+    """One hour of times at 10 minute frequency."""
+    mst = pytz.timezone('MST')
+    return pd.date_range(
+        start=datetime(2018, 6, 15, 12, 0, 0, tzinfo=mst),
+        end=datetime(2018, 6, 15, 13, 0, 0, tzinfo=mst),
+        freq='10T'
+    )
+
+
+def test_ghi_clearsky_limits(location, times):
+    """GHI values greater than clearsky values are flagged False."""
+    clearsky = location.get_clearsky(times)
+    ghi = clearsky['ghi'].copy()
+    ghi.iloc[0] *= 0.5
+    ghi.iloc[-1] *= 2.0
+    clear_times = np.tile(True, len(times))
+    clear_times[-1] = False
+    assert_series_equal(
+        irradiance.ghi_clearsky_limits(ghi, clearsky['ghi']),
+        pd.Series(index=times, data=clear_times)
+    )
+
+
+def test_poa_clearsky_limits():
+    """POA irradiance values greater than clearsky valuse are flagged False."""
+    index = pd.date_range(start=datetime(2019, 6, 15, 12, 0, 0),
+                          freq='15T', periods=5)
+    poa = pd.Series(index=index, data=[800, 1000, 1200, -200, np.nan])
+    poa_clearsky = pd.Series(index=index, data=1000)
+    assert_series_equal(
+        irradiance.poa_clearsky_limits(poa, poa_clearsky),
+        pd.Series(index=index, data=[True, True, False, True, False])
+    )
+    assert_series_equal(
+        irradiance.poa_clearsky_limits(poa, poa_clearsky, csi_max=1.2),
+        pd.Series(index=index, data=[True, True, True, True, False])
+    )

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import pytz
 import pandas as pd
 import numpy as np
-from pvlib.location import Location
 
 import pytest
 from pandas.util.testing import assert_series_equal
@@ -105,18 +104,6 @@ def test_check_irradiance_consistency_qcrad(irradiance_qcrad):
 
 
 @pytest.fixture
-def location():
-    """Fixture giving Albuquerque's location."""
-    return Location(
-        latitude=35.05,
-        longitude=-106.5,
-        altitude=1619,
-        name="Albuquerque",
-        tz="MST"
-    )
-
-
-@pytest.fixture
 def times():
     """One hour of times at 10 minute frequency."""
     mst = pytz.timezone('MST')
@@ -127,16 +114,16 @@ def times():
     )
 
 
-def test_ghi_clearsky_limits(location, times):
+def test_ghi_clearsky_limits(times):
     """GHI values greater than clearsky values are flagged False."""
-    clearsky = location.get_clearsky(times)
-    ghi = clearsky['ghi'].copy()
+    clearsky = pd.Series(np.linspace(50, 55, len(times)), index=times)
+    ghi = clearsky.copy()
     ghi.iloc[0] *= 0.5
     ghi.iloc[-1] *= 2.0
     clear_times = np.tile(True, len(times))
     clear_times[-1] = False
     assert_series_equal(
-        irradiance.ghi_clearsky_limits(ghi, clearsky['ghi']),
+        irradiance.ghi_clearsky_limits(ghi, clearsky),
         pd.Series(index=times, data=clear_times)
     )
 


### PR DESCRIPTION
Adds quality test to flag irradiance measurements that exceed the expected clearsky irradiance.

## Changes from SFA
* consolidate POA and GHI checks into a single function. These were separate in SFA, but ultimately do exactly the same thing. For pvanalytics it makes sense to consolidate them into a single general purpose function: `quality.irradiance.clearsky_limits()`.
* remove the `@mask_flags` decorator.
