### PR TITLE
Port detect_clipping from Solar Forecast Arbiter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,16 @@ spacing, time-shifts, and time zone validation.
 
    quality.time.spacing
 
+Features
+========
+
+Functions for detecting features in the data.
+
+.. autosummary::
+   :toctree: generated/
+
+   features.clipping_levels
+
 .. rubric:: References
 
 .. [1]  C. N. Long and Y. Shi, An Automated Quality Assessment and Control

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -35,3 +35,6 @@ the terms of the MIT License
 * The interpolation and stuck value detection functions
   :py:func:`pvanalytics.quality.gaps.interpolation()` and
   :py:func:`pvanalytics.quality.gaps.stale_values()`
+
+* Level-based clipping detection in
+  :py:func:`pvanalytics.features.clipping_levels`.

--- a/pvanalytics/features.py
+++ b/pvanalytics/features.py
@@ -45,15 +45,15 @@ def clipping_levels(ac_power, window=4, fraction_in_window=0.75,
     ----------
     ac_power : Series
         Time series of AC power measurements.
-    window : int
+    window : int, default 4
         Number of data points in a window used to detect clipping.
-    fraction_in_window : float
+    fraction_in_window : float, default 0.75
         Fraction of points which indicate clipping if AC power at each
         point is close to the plateau level.
-    rtol : float
+    rtol : float, default 5e-3
         A point is close to a clipped level M if
         abs(ac_power - M) < rtol * max(ac_power)
-    levels : int
+    levels : int, default 2
         Number of clipped power levels to consider.
 
     Returns

--- a/pvanalytics/features.py
+++ b/pvanalytics/features.py
@@ -12,7 +12,7 @@ def _detect_levels(x, count=3, num_bins=100):
         Data in which to find plateaus.
     count : int
         Number of pleataus to return.
-    num_bins : interpolated
+    num_bins : int
         Number of bins to use in histogram that finds plateau levels.
 
     Returns
@@ -37,7 +37,8 @@ def _label_clipping(x, window, frac):
     return y
 
 
-def clipping_levels(ac_power, window, fraction_in_window, rtol, levels):
+def clipping_levels(ac_power, window=4, fraction_in_window=0.75,
+                    rtol=5e-3, levels=2):
     """Label clipping in AC power data based on levels in the data.
 
     Parameters
@@ -64,7 +65,7 @@ def clipping_levels(ac_power, window, fraction_in_window, rtol, levels):
     num_bins = np.ceil(1.0 / rtol).astype(int)
     flags = pd.Series(index=ac_power.index, data=False)
     power_plateaus, bins = _detect_levels(ac_power, count=levels,
-                                         num_bins=num_bins)
+                                          num_bins=num_bins)
     for lower, upper in power_plateaus:
         temp = pd.Series(index=ac_power.index, data=0.0)
         temp.loc[(ac_power >= lower) & (ac_power <= upper)] = 1.0

--- a/pvanalytics/features.py
+++ b/pvanalytics/features.py
@@ -46,7 +46,7 @@ def clipping_levels(ac_power, window=4, fraction_in_window=0.75,
     ac_power : Series
         Time series of AC power measurements.
     window : int
-        Size of the window used to detect clipping.
+        Number of data points in a window used to detect clipping.
     fraction_in_window : float
         Fraction of points which indicate clipping if AC power at each
         point is close to the plateau level.

--- a/pvanalytics/features.py
+++ b/pvanalytics/features.py
@@ -1,1 +1,73 @@
 """Functions for identifying and labeling features."""
+import pandas as pd
+import numpy as np
+
+
+def _detect_levels(x, count=3, num_bins=100):
+    """Identify plateau levels in data.
+
+    Parameters
+    ----------
+    x : Series
+        Data in which to find plateaus.
+    count : int
+        Number of pleataus to return.
+    num_bins : interpolated
+        Number of bins to use in histogram that finds plateau levels.
+
+    Returns
+    -------
+    list of tuples
+        (left, right) values of the interval in x with a detected
+        plateau, in decreasing order of count of x values in the
+        interval. List length is given by `count`.
+
+    """
+    hist, bin_edges = np.histogram(x, bins=num_bins, density=True)
+    level_index = np.argsort(hist * -1)
+    levels = [(bin_edges[i], bin_edges[i + 1]) for i in level_index[:count]]
+    return levels, bin_edges
+
+
+def _label_clipping(x, window, frac):
+    # label points in a rolling window where the number of 1s is
+    # greater than window*frac
+    tmp = x.rolling(window).sum()
+    y = (tmp >= window * frac) & x.astype(bool)
+    return y
+
+
+def clipping_levels(ac_power, window, fraction_in_window, rtol, levels):
+    """Label clipping in AC power data based on levels in the data.
+
+    Parameters
+    ----------
+    ac_power : Series
+        Time series of AC power measurements.
+    window : int
+        Size of the window used to detect clipping.
+    fraction_in_window : float
+        Fraction of points which indicate clipping if AC power at each
+        point is close to the plateau level.
+    rtol : float
+        A point is close to a clipped level M if
+        abs(ac_power - M) < rtol * max(ac_power)
+    levels : int
+        Number of clipped power levels to consider.
+
+    Returns
+    -------
+    Series
+        True when clipping is indicated.
+
+    """
+    num_bins = np.ceil(1.0 / rtol).astype(int)
+    flags = pd.Series(index=ac_power.index, data=False)
+    power_plateaus, bins = _detect_levels(ac_power, count=levels,
+                                         num_bins=num_bins)
+    for lower, upper in power_plateaus:
+        temp = pd.Series(index=ac_power.index, data=0.0)
+        temp.loc[(ac_power >= lower) & (ac_power <= upper)] = 1.0
+        flags = flags | _label_clipping(temp, window=window,
+                                        frac=fraction_in_window)
+    return flags

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -8,14 +8,14 @@ from pvanalytics import features
 
 @pytest.fixture
 def quadratic():
-    """A downward facing quadratic with vertex at (0, 1000) and roots at +/-1."""
+    """Downward facing quadratic with vertex at (0, 1000) and roots at +/-1."""
     q = -1000 * (np.linspace(-1, 1, 60) ** 2) + 1000
     return pd.Series(q)
 
 
 @pytest.fixture
 def quadratic_clipped(quadratic):
-    """A downward facing quadratic with clipping at y=800"""
+    """Downward facing quadratic with clipping at y=800"""
     return np.minimum(quadratic, 800)
 
 

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -10,10 +10,10 @@ from pvanalytics import features
 def quadratic():
     """Downward facing quadratic.
 
-    Vertex at (30.5, 1000) and roots at 0, 59.
+    Vertex at index 30 and roots at indices 0, 60.
 
     """
-    q = -1000 * (np.linspace(-1, 1, 60) ** 2) + 1000
+    q = -1000 * (np.linspace(-1, 1, 61) ** 2) + 1000
     return pd.Series(q)
 
 

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -55,3 +55,24 @@ def test_clipping_levels_compound_clipped(quadratic, quadratic_clipped):
     """Clipping is identified in summed quadratics when one quadratic has
     clipping."""
     assert features.clipping_levels(quadratic + quadratic_clipped).any()
+
+
+def test_clipping_levels_two_periods(quadratic, quadratic_clipped):
+    """Two periods of clipping with lower values between them.
+
+    The two periods of clipping should be flagged as clipping, and the
+    central period of lower values should not be marked as clipping.
+    """
+    quadratic_clipped.loc[28:31] = [750, 725, 700, 650]
+    clipping = features.clipping_levels(
+        quadratic_clipped,
+        window=4,
+        fraction_in_window=0.5,
+        levels=4,
+        rtol=5e-3
+    )
+    assert not clipping[29:33].any()
+    assert clipping[20:28].all()
+    assert clipping[35:40].all()
+    assert not clipping[0:10].any()
+    assert not clipping[50:].any()

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -19,12 +19,6 @@ def quadratic_clipped(quadratic):
     return np.minimum(quadratic, 800)
 
 
-@pytest.fixture
-def quadratic_compound(quadratic):
-    """A sum of two quadratics."""
-    return quadratic + quadratic
-
-
 def test_clipping_levels(quadratic, quadratic_clipped):
     """The clipped segment of a quadratic is properly identified."""
     expected = quadratic >= 800

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -1,0 +1,43 @@
+"""Tests for feature labeling functions."""
+import pytest
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+import numpy as np
+from pvanalytics import features
+
+
+@pytest.fixture
+def quadratic():
+    """A downward facing quadratic."""
+    q = -1000 * (np.linspace(-1, 1, 60) ** 2) + 1000
+    return pd.Series(q)
+
+
+@pytest.fixture
+def quadratic_clipped(quadratic):
+    """A downward facing quadratic with clipping"""
+    return np.minimum(quadratic, 800)
+
+
+def test_clipping_levels(quadratic, quadratic_clipped):
+    """The clipped segment of a quadratic is properly identified."""
+    expected = quadratic >= 800
+    # because of the rolling window, the first clipped value in the
+    # clipped series will not be marked as clipped (< 1/2 of the
+    # values will be in a different level until there are at least two
+    # clipped values in the window [for window=4])
+    first_true = expected[quadratic >= 800].index[0]
+    expected.loc[first_true] = False
+    assert_series_equal(
+        expected,
+        features.clipping_levels(
+            quadratic_clipped, window=4,
+            fraction_in_window=0.5, levels=4, rtol=5e-3)
+    )
+
+
+def test_clipping_levels_no_clipping(quadratic):
+    """No clipping is identified in a data set that is jsut a quadratic."""
+    assert not features.clipping_levels(
+        quadratic, window=10, fraction_in_window=0.75, levels=4, rtol=5e-3
+    ).any()

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -8,7 +8,11 @@ from pvanalytics import features
 
 @pytest.fixture
 def quadratic():
-    """Downward facing quadratic with vertex at (0, 1000) and roots at +/-1."""
+    """Downward facing quadratic.
+
+    Vertex at (30.5, 1000) and roots at 0, 59.
+
+    """
     q = -1000 * (np.linspace(-1, 1, 60) ** 2) + 1000
     return pd.Series(q)
 

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -19,6 +19,12 @@ def quadratic_clipped(quadratic):
     return np.minimum(quadratic, 800)
 
 
+@pytest.fixture
+def quadratic_compound(quadratic):
+    """A sum of two quadratics."""
+    return quadratic + quadratic
+
+
 def test_clipping_levels(quadratic, quadratic_clipped):
     """The clipped segment of a quadratic is properly identified."""
     expected = quadratic >= 800
@@ -41,3 +47,17 @@ def test_clipping_levels_no_clipping(quadratic):
     assert not features.clipping_levels(
         quadratic, window=10, fraction_in_window=0.75, levels=4, rtol=5e-3
     ).any()
+
+
+def test_clipping_levels_compound(quadratic):
+    """No clipping is identified in the sum of two quadratics"""
+    qsum = quadratic + quadratic
+    assert not features.clipping_levels(
+        qsum, window=10, fraction_in_window=0.75, levels=4, rtol=5e-3
+    ).any()
+
+
+def test_clipping_levels_compound_clipped(quadratic, quadratic_clipped):
+    """Clipping is identified in summed quadratics when one quadratic has
+    clipping."""
+    assert features.clipping_levels(quadratic + quadratic_clipped).any()

--- a/pvanalytics/tests/test_features.py
+++ b/pvanalytics/tests/test_features.py
@@ -8,14 +8,14 @@ from pvanalytics import features
 
 @pytest.fixture
 def quadratic():
-    """A downward facing quadratic."""
+    """A downward facing quadratic with vertex at (0, 1000) and roots at +/-1."""
     q = -1000 * (np.linspace(-1, 1, 60) ** 2) + 1000
     return pd.Series(q)
 
 
 @pytest.fixture
 def quadratic_clipped(quadratic):
-    """A downward facing quadratic with clipping"""
+    """A downward facing quadratic with clipping at y=800"""
     return np.minimum(quadratic, 800)
 
 


### PR DESCRIPTION
Detects inverter clipping based on levels in the data.

## Changes from SFA
* `detect_clipping` renamed to `features.clipping_levels`
* remove `@mask_flags` decorator
* rewrote tests to avoid depending on pvlib to generate data.