### PR TITLE
Port detect_clearsky from Solar Forecast Arbiter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -103,6 +103,14 @@ Functions for identifying inverter clipping
 
    features.clipping.levels
 
+Clearsky
+--------
+
+.. autosummary::
+   :toctree: generated/
+
+   features.clearsky.reno
+
 .. rubric:: References
 
 .. [1]  C. N. Long and Y. Shi, An Automated Quality Assessment and Control

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -31,7 +31,7 @@ the terms of the MIT License
 
 * The implementation of the QCRad algorithm in
   :py:mod:`pvanalytics.quality.irradiance`
-  
+
 * The clearsky limits quality check
   :py:func:`pvanalytics.quality.irradiance.clearsky_limits`
 
@@ -49,3 +49,6 @@ the terms of the MIT License
 
 * Level-based clipping detection in
   :py:func:`pvanalytics.features.clipping.levels`.
+
+* Clear sky detection in
+  :py:func:`pvanalytics.features.clearsky.reno`

--- a/pvanalytics/features/clearsky.py
+++ b/pvanalytics/features/clearsky.py
@@ -1,0 +1,74 @@
+"""Functions for identifying periods of clear sky conditions."""
+import numpy as np
+import pvlib
+
+
+def clearsky(ghi, ghi_clearsky):
+    """Identify time when GHI is consistent with clearsky conditions.
+
+    Uses the function :py:func:`pvlib.clearsky.detect_clearsky`.
+
+    .. note::
+
+       Must be given GHI data with regular (constant) time intervals
+       of 15 minutes or less.
+
+    Parameters
+    ----------
+    ghi : Series
+        Global horizontal irradiance in :math:`W/m^2`. Must have an
+        index with time intervals of at most 15 minutes.
+    ghi_clearsky : Series
+        Global horizontal irradiance in :math:`W/m^2` under clearsky
+        conditions.
+
+    Returns
+    -------
+    Series
+        True when clear sky conditions are indicated.
+
+    Raises
+    ------
+    ValueError
+        if the time intervals are greater than 15 minutes.
+
+    Notes
+    -----
+    Clear-sky conditions are inferred when each of six criteria are
+    met; see :py:func:`pvlib.clearsky.detect_clearsky` for references
+    and details. Threshold values for each criterion were originally
+    developed for ten minute windows containing one-minute data
+    [1]_. As indicated in [2]_, the algorithm also works for longer
+    windows and data at different intervals if threshold criteria are
+    roughly scaled to the window length. Here, the threshold values
+    are based on [1] with the scaling indicated in [2].
+
+    References
+    ----------
+    .. [1] Reno, M.J. and C.W. Hansen, "Identification of periods of
+       clear sky irradiance in time series of GHI measurements"
+       Renewable Energy, v90, p. 520-531, 2016.
+
+    .. [2] B. H. Ellis, M. Deceglie and A. Jain, "Automatic Detection
+       of Clear-Sky Periods From Irradiance Data," in IEEE Journal of
+       Photovoltaics, vol. 9, no. 4, pp. 998-1005, July 2019. doi:
+       10.1109/JPHOTOV.2019.2914444
+
+    """
+    delta = ghi.index.to_series().diff()
+    delta_minutes = delta[1] / np.timedelta64(1, '60s')
+    if delta_minutes > 15:
+        raise ValueError('clearsky requires regular time intervals '
+                         'of 15m or less')
+    window_length = np.minimum(10*delta_minutes, 60.0)
+    scale_factor = window_length / 10
+    flags = pvlib.clearsky.detect_clearsky(
+        ghi,
+        ghi_clearsky,
+        ghi.index,
+        window_length,
+        lower_line_length=-5*scale_factor,
+        upper_line_length=10*scale_factor,
+        slope_dev=8*scale_factor
+    )
+    return flags

--- a/pvanalytics/features/clearsky.py
+++ b/pvanalytics/features/clearsky.py
@@ -3,8 +3,8 @@ import numpy as np
 import pvlib
 
 
-def clearsky(ghi, ghi_clearsky):
-    """Identify time when GHI is consistent with clearsky conditions.
+def reno(ghi, ghi_clearsky):
+    """Identify times when GHI is consistent with clearsky conditions.
 
     Uses the function :py:func:`pvlib.clearsky.detect_clearsky`.
 

--- a/pvanalytics/tests/features/conftest.py
+++ b/pvanalytics/tests/features/conftest.py
@@ -1,0 +1,15 @@
+"""Common fixtures for features tests."""
+import pytest
+import numpy as np
+import pandas as pd
+
+
+@pytest.fixture
+def quadratic():
+    """Downward facing quadratic.
+
+    Vertex at index 30 and roots at indices 0, 60.
+
+    """
+    q = -1000 * (np.linspace(-1, 1, 61) ** 2) + 1000
+    return pd.Series(q)

--- a/pvanalytics/tests/features/test_clearsky.py
+++ b/pvanalytics/tests/features/test_clearsky.py
@@ -1,0 +1,38 @@
+"""Tests for feature labeling functions."""
+import pytest
+import pandas as pd
+from pvanalytics.features import clearsky
+
+
+@pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
+def test_reno_identical(quadratic):
+    """Identical clearsky and measured irradiance all True"""
+    index = pd.date_range(start='04/03/2020', freq='15T',
+                          periods=len(quadratic))
+    quadratic.index = index
+    assert clearsky.reno(quadratic, quadratic).all()
+
+
+@pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in")
+def test_reno_begining_end(quadratic):
+    """clearsky conditions except in the middle of the dataset"""
+    index = pd.date_range(start='03/03/2020', freq='15T',
+                          periods=len(quadratic))
+    quadratic.index = index
+    ghi = quadratic.copy()
+    ghi.iloc[20:31] *= 0.5
+    ghi.iloc[31:41] = 0
+    clear_times = clearsky.reno(ghi, quadratic)
+    assert clear_times[0:20].all()
+    assert not clear_times[21:40].any()
+    assert clear_times[41:].all()
+
+
+def test_reno_large_interval(quadratic):
+    """clearsky.reno() raises ValueError if timestamp spacing too large."""
+    index = pd.date_range(start='04/03/2020', freq='20T',
+                          periods=len(quadratic))
+    quadratic.index = index
+    with pytest.raises(ValueError):
+        clearsky.reno(quadratic, quadratic)

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -1,20 +1,8 @@
 """Tests for features.clipping"""
 import pytest
-import pandas as pd
 from pandas.util.testing import assert_series_equal
 import numpy as np
 from pvanalytics.features import clipping
-
-
-@pytest.fixture
-def quadratic():
-    """Downward facing quadratic.
-
-    Vertex at index 30 and roots at indices 0, 60.
-
-    """
-    q = -1000 * (np.linspace(-1, 1, 61) ** 2) + 1000
-    return pd.Series(q)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes from SFA
* renamed `validator.detect_clearsky` to `features.clearsky.reno`
* wrote new tests that do not depend on pvlib to generate cleasky data.