### PR TITLE
Trim leading and trailing periods of missing data

### DIFF
--- a/LICENSES/PVFLEETS_QA_LICENSE
+++ b/LICENSES/PVFLEETS_QA_LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,7 +61,7 @@ The following functions identify days with incomplete data.
    quality.gaps.daily_completeness
    quality.gaps.complete
 
-Many data sets may have leading and trailing periods with sparodic or
+Many data sets may have leading and trailing periods of days with sporadic or
 no data. The following functions can be used to remove those periods.
 
 .. autosummary::
@@ -133,4 +133,3 @@ Clearsky
 .. [1]  C. N. Long and Y. Shi, An Automated Quality Assessment and Control
         Algorithm for Surface Radiation Measurements, The Open Atmospheric
         Science Journal 2, pp. 23-37, 2008.
-

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,13 +53,21 @@ Identify gaps in the data.
    quality.gaps.interpolation_diff
    quality.gaps.stale_values_diff
 
+The following functions identify days with incomplete data.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.gaps.daily_completeness
+   quality.gaps.complete
+
 Many data sets may have leading and trailing periods with sparodic or
 no data. The following functions can be used to remove those periods.
 
 .. autosummary::
    :toctree: generated/
 
-   quality.gaps.valid_between
+   quality.gaps.start_stop_dates
    quality.gaps.trim
 
 Outliers

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,7 +58,7 @@ The following functions identify days with incomplete data.
 .. autosummary::
    :toctree: generated/
 
-   quality.gaps.daily_completeness
+   quality.gaps.completeness_score
    quality.gaps.complete
 
 Many data sets may have leading and trailing periods of days with sporadic or

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,15 @@ Identify gaps in the data.
    quality.gaps.interpolation_diff
    quality.gaps.stale_values_diff
 
+Many data sets may have leading and trailing periods with sparodic or
+no data. The following functions can be used to remove those periods.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.gaps.valid_between
+   quality.gaps.trim
+
 Outliers
 --------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,6 +69,7 @@ no data. The following functions can be used to remove those periods.
 
    quality.gaps.start_stop_dates
    quality.gaps.trim
+   quality.gaps.trim_incomplete
 
 Outliers
 --------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -277,6 +277,28 @@ def start_stop_dates(series, days=10):
     return start, end
 
 
+def trim(series, days=10):
+    """Mask the begining and end of the data if there are gaps.
+
+    Parameters
+    ----------
+    series : Series
+        A DatetimeIndexed series of booleans
+    days : int, default 10
+        Minimum number of consecutive days that are all True for
+        'good' data to start.
+
+    Returns
+    -------
+    Series
+        A series of booleans with True for all data points between the
+        first and last block of `days` consecutive days that are all
+        True in `series`
+
+    """
+    pass
+
+
 def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
     """Mask out missing data from the beginning and end of the data.
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -226,33 +226,31 @@ def complete(series, threshold=0.333, freq=None):
     return (completeness >= threshold).reindex(series.index, method='pad')
 
 
-def valid_between(series, days=10, minimum_completeness=0.333333, freq=None):
-    """Get the start and end of valid data.
+def start_stop_dates(series, days=10, minimum_completeness=0.333333,
+                     freq=None):
+    """Get the start and end of data excluding leading and trailing gaps.
 
     The start and end dates returned by this function can be used to
     remove large periods of missing data from the begining and end of
-    the series. The valid data begins when there are `days`
-    consecutive days with valid data covering at least `minimum_hours`
-    on each day. Valid data ends on the last day with `days`
-    consecutive days with data covering at least `minimum_hours`
-    preceeding it.
-
-    Any data point with a value other than `NaN` is considered valid
-    data.
+    the series. The data starts when there are `days` consecutive days
+    with completeness greater than `minimum_completeness` (see
+    :py:func:`daily_completeness`) and ends on the last day with
+    `days` consecutive days with completeness at least
+    `minimum_completeness` preceeding it.
 
     Parameters
     ----------
     series : Series
-        A datetime indexed series.
-    days : int
+        A DatetimeIndexed series.
+    days : int, default 10
         The minimum number of consecutive valid days for data to be
         considered valid.
-    minimum_hours : float
-        The number of hours that must have valid data for a day to be
-        considered valid.
+    minimum_completeness : float, default 0.333333
+        The fraction of a day that must have data for the day to be
+        considered complete.
     freq : string or None, default None
-        The frequency to the series. If None, then frequency is
-        inferred from the index.
+        The frequency of data in the series. If None, then frequency
+        is inferred from the index.
 
     Returns
     -------
@@ -261,6 +259,10 @@ def valid_between(series, days=10, minimum_completeness=0.333333, freq=None):
         of valid days then None is returned.
     end : Datetime or None
         The last valid day. None if start is None.
+
+    See Also
+    --------
+    :py:func:`daily_completeness`
 
     Notes
     -----
@@ -319,7 +321,7 @@ def trim(series, **kwargs):
         last good day, and False from the last good day to the end.
 
     """
-    start, end = valid_between(series, **kwargs)
+    start, end = start_stop_dates(series, **kwargs)
     s = pd.Series(index=series.index, dtype='bool')
     s.loc[:] = False
     if start:

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -224,15 +224,21 @@ def daily_completeness(series, freq=None):
     """Calculate a completeness index for each day in the data.
 
     The completeness for a given day is the fraction of time in the
-    day for which there is data (a value other than NaN).
+    day for which there is data (a value other than NaN). The amount
+    of time that a value is attributed is equal to the timestamp
+    spacing in `series` or `freq` if it is specified. For example, a
+    day with 24 non-NaN values in a series with 30 minute timestamp
+    spacing would have 12 hours of data and therefore completeness of
+    0.5.
 
     Parameters
     ----------
     series : Series
         A DatetimeIndexed series.
     freq : string, default None
-        interval between samples in the series. If None, the frequency
-        is inferred using :py:func:`pandas.infer_freq`.
+        Interval between samples in the series, as a pandas frequency
+        string. If None, the frequency is inferred using
+        :py:func:`pandas.infer_freq`.
 
     Returns
     -------
@@ -259,6 +265,13 @@ def daily_completeness(series, freq=None):
 
 def complete(series, threshold=0.333, freq=None):
     """Select only data points that are part of a day with complete data.
+
+    A day has complete data if the fraction of the day that has
+    non-NaN values is at least `threshold`. The fraction of the day
+    assigned to each value is equal to the timestamp spacing of the
+    series or `freq` if it is provided. For example, a day with 24
+    non-NaN values in a series with 30 minute timestamp spacing would
+    have 12 hours of data and therefore completeness of 0.5.
 
     Parameters
     ----------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -211,6 +211,35 @@ def valid_between(series, days=10, minimum_hours=7.75, freq=None):
     return start, end
 
 
+def daily_completeness(series, freq=None):
+    """Calculate a completeness index for each day in the data.
+
+    The completeness for a given day is the fraction of time in the
+    day for which there is data (a value other than NaN).
+
+    Parameters
+    ----------
+    series : Series
+        A DatetimeIndexed series.
+    freq : string, default None
+        interval between samples in the series. If None, the frequency
+        is inferred using :py:func:`pandas.infer_freq`.
+
+    Returns
+    -------
+    Series
+        A series of floats indexed by day giving the completeness of
+        each day (fraction of hours in the day for which `series` has
+        data).
+
+    """
+    seconds_per_sample = pd.Timedelta(
+        freq or pd.infer_freq(series.index)
+    ).seconds
+    daily_counts = series.resample('D').count()
+    return (daily_counts * seconds_per_sample) / (1440*60)
+
+
 def trim(series, **kwargs):
     """Mask out missing data from the begining and end of the data.
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -278,7 +278,7 @@ def start_stop_dates(series, days=10):
 
 
 def trim(series, days=10):
-    """Mask the begining and end of the data if there are gaps.
+    """Mask the beginning and end of the data if not all True.
 
     Parameters
     ----------
@@ -293,7 +293,13 @@ def trim(series, days=10):
     Series
         A series of booleans with True for all data points between the
         first and last block of `days` consecutive days that are all
-        True in `series`
+        True in `series`. If `series` does not contain such a block of
+        consecutive True values, then the returned series will be
+        entirely False.
+
+    See Also
+    --------
+    :py:func:`start_stop_dates`
 
     """
     start, end = start_stop_dates(series, days=days)
@@ -304,11 +310,9 @@ def trim(series, days=10):
 
 
 def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
-    """Mask out missing data from the beginning and end of the data.
+    """Trim the series based on the completeness score.
 
-    False for times preceeding the start date and following the stop date
-    returned by :py:func:`start_stop_dates`. If no start and stop
-    dates are identified then a series of all False is returned.
+    Combines :py:func:`completeness_score` and :py:func:`trim`.
 
     Parameters
     ----------
@@ -334,7 +338,7 @@ def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
 
     See Also
     --------
-    :py:func:`start_stop_dates`
+    :py:func:`trim`
 
     :py:func:`completeness_score`
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -296,7 +296,11 @@ def trim(series, days=10):
         True in `series`
 
     """
-    pass
+    start, end = start_stop_dates(series, days=days)
+    mask = pd.Series(False, index=series.index)
+    if start:
+        mask.loc[start.date():end.date()] = True
+    return mask
 
 
 def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
@@ -335,11 +339,6 @@ def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
     :py:func:`completeness_score`
 
     """
-    completeness = completeness_score(series, freq=freq, keep_index=False)
+    completeness = completeness_score(series, freq=freq)
     complete_days = completeness >= minimum_completeness
-    start, end = start_stop_dates(complete_days, days=days)
-    mask = pd.Series(index=series.index, dtype='bool')
-    mask.loc[:] = False
-    if start:
-        mask.loc[start.date():end.date()] = True
-    return mask
+    return trim(complete_days, days=days)

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -224,9 +224,9 @@ def trim(series, **kwargs):
     Returns
     -------
     Series
-      A series of booleans whith the same index as `series` with False
-      up to the first good day, True from the first to the last good
-      day, and False from the last good day to the end.
+        A series of booleans with the same index as `series` with
+        False up to the first good day, True from the first to the
+        last good day, and False from the last good day to the end.
 
     """
     start, end = valid_between(series, **kwargs)

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -282,7 +282,8 @@ def complete(series, threshold=0.333, freq=None):
         See :py:func:`daily_completeness`.
 
     """
-    pass
+    completeness = daily_completeness(series, freq)
+    return (completeness >= threshold).reindex(series.index, method='pad')
 
 
 def trim(series, **kwargs):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -139,8 +139,6 @@ def interpolation_diff(x, window=3, rtol=1e-5, atol=1e-8):
 
 
 def _freq_to_seconds(freq):
-    if not freq:
-        return None
     if freq.isalpha():
         freq = '1' + freq
     delta = pd.to_timedelta(freq)
@@ -183,8 +181,12 @@ def completeness_score(series, freq=None, keep_index=True):
 
     """
     inferred_seconds = _freq_to_seconds(pd.infer_freq(series.index))
-    freq_seconds = _freq_to_seconds(freq)
-    seconds_per_sample = freq_seconds or inferred_seconds
+    if freq:
+        freq_seconds = _freq_to_seconds(freq)
+        seconds_per_sample = freq_seconds
+    else:
+        seconds_per_sample = inferred_seconds
+
     if freq and inferred_seconds < freq_seconds:
         raise ValueError("freq must be less than or equal to the"
                          + " frequency of the series")

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -202,7 +202,7 @@ def complete(series, minimum_completeness=0.333, freq=None):
 
     A day has complete data if its completeness score is greater than
     or equal to `minimum_completeness`. The completeness score is
-    calculated by :py:func:`daily_completeness`.
+    calculated by :py:func:`completeness_score`.
 
     Parameters
     ----------
@@ -223,11 +223,11 @@ def complete(series, minimum_completeness=0.333, freq=None):
     Raises
     ------
     ValueError
-        See :py:func:`daily_completeness`.
+        See :py:func:`completeness_score`.
 
     See Also
     --------
-    :py:func:`daily_completeness`
+    :py:func:`completeness_score`
 
     """
     return completeness_score(series, freq=freq) >= minimum_completeness

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -189,21 +189,21 @@ def daily_completeness(series, freq=None):
     return (daily_counts * seconds_per_sample) / (1440*60)
 
 
-def complete(series, threshold=0.333, freq=None):
+def complete(series, minimum_completeness=0.333, freq=None):
     """Select only data points that are part of a day with complete data.
 
     A day is complete if its completeness score is greater than or
-    equal to `threshold`. See :py:func:`daily_completeness` for more
+    equal to `minimum_completeness`. See :py:func:`daily_completeness` for more
     information. For example, a day with 24 non-NaN values in a series
     with 30 minute timestamp spacing would have 12 hours of data and
     therefore a completeness score of 0.5; with the default
-    `threshold=0.333` the day would be marked complete.
+    `minimum_completeness=0.333` the day would be marked complete.
 
     Parameters
     ----------
     series : Series
         The data to be checked for completeness.
-    threshold : float, default 0.333
+    minimum_completeness : float, default 0.333
         Fraction of the day that must have data.
     freq : str, default None
         The expected frequency of the data in `series`. If none then
@@ -213,7 +213,7 @@ def complete(series, threshold=0.333, freq=None):
     -------
     Series
         A series of booleans with True for each value that is part of
-        a day with completeness greater than `threshold`.
+        a day with completeness greater than `minimum_completeness`.
 
     Raises
     ------
@@ -226,7 +226,8 @@ def complete(series, threshold=0.333, freq=None):
 
     """
     completeness = daily_completeness(series, freq)
-    return (completeness >= threshold).reindex(series.index, method='pad')
+    return ((completeness >= minimum_completeness)
+            .reindex(series.index, method='pad'))
 
 
 def start_stop_dates(series, days=10, minimum_completeness=0.333333,

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -170,6 +170,15 @@ def valid_between(series, days=10, minimum_hours=7.75, freq=None):
     end : Datetime or None
         The last valid day. None if start is None.
 
+    Notes
+    -----
+    This function was derived from the pvfleets_qa_analysis project,
+    Copyright (c) 2020 Alliance for Sustainable Energy, LLC. See the
+    file LICENSES/PVFLEETS_QA_LICENSE at the top level directory of
+    this distribution and at `<https://github.com/pvlib/
+    pvanalytics/blob/master/LICENSES/PVFLEETS_QA_LICENSE>`_ for more
+    information.
+
     """
     freq_hours = (pd.Timedelta(freq or pd.infer_freq(series.index)).seconds
                   / (60.0*60.0))

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -257,6 +257,34 @@ def daily_completeness(series, freq=None):
     return (daily_counts * seconds_per_sample) / (1440*60)
 
 
+def complete(series, threshold=0.333, freq=None):
+    """Select only data points that are part of a day with complete data.
+
+    Parameters
+    ----------
+    series : Series
+        The data to be checked for completeness.
+    threshold : float, default 0.333
+        Fraction of the day that must have data.
+    freq : str, default None
+        The expected frequency of the data in `series`. If none then
+        the frequency is inferred from the data.
+
+    Returns
+    -------
+    Series
+        A series of booleans with True for each value that is part of
+        a day with completeness greater than `threshold`.
+
+    Raises
+    ------
+    ValueError
+        See :py:func:`daily_completeness`.
+
+    """
+    pass
+
+
 def trim(series, **kwargs):
     """Mask out missing data from the begining and end of the data.
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -148,14 +148,15 @@ def _freq_to_seconds(freq):
 
 
 def daily_completeness(series, freq=None):
-    """Calculate a completeness score for each day.
+    """Calculate a data completeness score for each day.
 
     The completeness score for a given day is the fraction of time in
     the day for which there is data (a value other than NaN). The time
-    attributed to each value is equal to the timestamp spacing of
-    `series` or `freq` if it is specified. For example, a day with 24
-    non-NaN values in a series with 30 minute timestamp spacing would
-    have 12 hours of data and therefore completeness score of 0.5.
+    duration attributed to each value is equal to the timestamp
+    spacing of `series` or `freq` if it is specified. For example, a
+    24-hour time series with 30 minute timestamp spacing and 24
+    non-NaN values would have data for a total of 12 hours and
+    therefore a completeness score of 0.5.
 
     Parameters
     ----------
@@ -190,14 +191,11 @@ def daily_completeness(series, freq=None):
 
 
 def complete(series, minimum_completeness=0.333, freq=None):
-    """Select only data points that are part of a day with complete data.
+    """Select data points that are part of days with complete data.
 
-    A day is complete if its completeness score is greater than or
-    equal to `minimum_completeness`. See :py:func:`daily_completeness` for more
-    information. For example, a day with 24 non-NaN values in a series
-    with 30 minute timestamp spacing would have 12 hours of data and
-    therefore a completeness score of 0.5; with the default
-    `minimum_completeness=0.333` the day would be marked complete.
+    A day has complete data if its completeness score is greater than
+    or equal to `minimum_completeness`. The completeness score is
+    calculated by :py:func:`daily_completeness`.
 
     Parameters
     ----------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -151,7 +151,7 @@ def completeness_score(series, freq=None, keep_index=True):
     The completeness score for a given day is the fraction of time in
     the day for which there is data (a value other than NaN). The time
     duration attributed to each value is equal to the timestamp
-    spacing of `series` or `freq` if it is specified. For example, a
+    spacing of `series`, or `freq` if it is specified. For example, a
     24-hour time series with 30 minute timestamp spacing and 24
     non-NaN values would have data for a total of 12 hours and
     therefore a completeness score of 0.5.
@@ -306,7 +306,7 @@ def trim(series, days=10):
 def trim_incomplete(series, minimum_completeness=0.333333, days=10, freq=None):
     """Mask out missing data from the beginning and end of the data.
 
-    Removes data preceeding the start date and following the stop date
+    False for times preceeding the start date and following the stop date
     returned by :py:func:`start_stop_dates`. If no start and stop
     dates are identified then a series of all False is returned.
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -199,7 +199,7 @@ def valid_between(series, days=10, minimum_hours=7.75, freq=None):
 
 
 def trim(series, **kwargs):
-    """Remove missing data from the begining and end of the dataset.
+    """Mask out missing data from the begining and end of the data.
 
     Missing data is determined by the criteria in
     :py:func:`valid_between`.
@@ -207,19 +207,22 @@ def trim(series, **kwargs):
     Parameters
     ----------
     series : Series
-        A DatatimeIndexed series
+        A DatatimeIndexed series.
     kwargs :
         Any of the keyword arguments that can be passed to
-        :py:func:`valid_between`
+        :py:func:`valid_between`.
 
     Returns
     -------
-    Series or None
-        The same series with leading and trailing `NA`s removed. If
-        there is no valid data None is returned
+    Series
+      A series of booleans whith the same index as `series` with False
+      up to the first good day, True from the first to the last good
+      day, and False from the last good day to the end.
 
     """
     start, end = valid_between(series, **kwargs)
+    s = pd.Series(index=series.index, dtype='bool')
+    s.loc[:] = False
     if start:
-        return series[start.date():end.date()]
-    return None
+        s.loc[start.date():end.date()] = True
+    return s

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -144,9 +144,13 @@ def valid_between(series, days=10, minimum_hours=7.75, freq=None):
     The start and end dates returned by this function can be used to
     remove large periods of missing data from the begining and end of
     the series. The valid data begins when there are `days`
-    consecutive days with data covering at least `minimum_hours` on
-    each day. Valid data ends on the last day with `days` consecutive
-    days with data covering at least `minimum_hours` preceeding it.
+    consecutive days with valid data covering at least `minimum_hours`
+    on each day. Valid data ends on the last day with `days`
+    consecutive days with data covering at least `minimum_hours`
+    preceeding it.
+
+    Any data point with a value other than `NaN` is considered valid
+    data.
 
     Parameters
     ----------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -225,9 +225,8 @@ def complete(series, minimum_completeness=0.333, freq=None):
     :py:func:`daily_completeness`
 
     """
-    completeness = daily_completeness(series, freq)
-    return ((completeness >= minimum_completeness)
-            .reindex(series.index, method='pad'))
+    complete_days = daily_completeness(series, freq) >= minimum_completeness
+    return complete_days.reindex(series.index, method='pad')
 
 
 def start_stop_dates(series, days=10, minimum_completeness=0.333333,

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -338,8 +338,8 @@ def trim(series, **kwargs):
 
     """
     start, end = start_stop_dates(series, **kwargs)
-    s = pd.Series(index=series.index, dtype='bool')
-    s.loc[:] = False
+    mask = pd.Series(index=series.index, dtype='bool')
+    mask.loc[:] = False
     if start:
-        s.loc[start.date():end.date()] = True
-    return s
+        mask.loc[start.date():end.date()] = True
+    return mask

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -355,6 +355,10 @@ def test_valid_between_with_gaps_in_middle():
 
 
 def test_trim():
+    """gaps.trim() should return a boolean mask that selects only the good
+    data in the middle of a series.
+
+    """
     index = pd.date_range(
         freq='15T',
         start='01-01-2020',
@@ -367,3 +371,15 @@ def test_trim():
         series[gaps.trim(series, days=3)],
         series['01-07-2020':'08-01-2020 00:00']
     )
+
+
+def test_trim_empty():
+    """gaps.trim() returns all False for series with no valid days."""
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, dtype='float64')
+    series.iloc[::(24*60)] = 1
+    assert (~gaps.trim(series, days=3)).all()

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -1,6 +1,7 @@
 """Tests for gaps quality control functions."""
 import pytest
 import pandas as pd
+import numpy as np
 from pandas.util.testing import assert_series_equal
 from pvanalytics.quality import gaps
 
@@ -203,3 +204,167 @@ def test_interpolation_diff_raises_error(interpolated_data):
     """
     with pytest.raises(ValueError):
         gaps.interpolation_diff(interpolated_data, window=2)
+
+
+def test_valid_between_no_missing_data():
+    """If there is no missing data firstlastvaliddays should return the
+    start and end of the series.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(
+        data=np.full(len(index), 10),
+        index=index
+    )
+    firstvalid, lastvalid = gaps.valid_between(series)
+    assert firstvalid.date() == pd.Timestamp('01-01-2020').date()
+    assert lastvalid.date() == pd.Timestamp('08-01-2020').date()
+
+
+def test_first_day_missing_data():
+    """If the first day is missing data, the first valid date should be
+    the second day.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    data = np.full(len(index), 10)
+    series = pd.Series(data=data, index=index)
+    series['01-01-2020 00:00':'01-02-2020 00:00'] = np.nan
+    firstvalid, lastvalid = gaps.valid_between(series)
+    assert firstvalid.date() == pd.Timestamp('01-02-2020').date()
+    assert lastvalid.date() == pd.Timestamp('08-01-2020').date()
+
+
+def test_first_and_fifth_days_missing():
+    """First valid date should be the sixth of January."""
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    data = np.full(len(index), 10)
+    series = pd.Series(data=data, index=index)
+    series['01-01-2020 00:00':'01-02-2020 00:00'] = np.nan
+    series['01-05-2020 00:00':'01-06-2020 00:00'] = np.nan
+    firstvalid, lastvalid = gaps.valid_between(series)
+    assert firstvalid.date() == pd.Timestamp('01-06-2020').date()
+    assert lastvalid.date() == pd.Timestamp('08-01-2020').date()
+
+
+def test_last_two_days_missing():
+    """If the last two days of data are missing last valid day should be
+    July 30.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    data = np.full(len(index), 10)
+    series = pd.Series(data=data, index=index)
+    series['07-31-2020 00:00':'08-01-2020 23:00'] = np.nan
+    firstvalid, lastvalid = gaps.valid_between(series)
+    assert firstvalid.date() == pd.Timestamp('01-01-2020').date()
+    assert lastvalid.date() == pd.Timestamp('07-30-2020').date()
+
+
+def test_valid_between_no_data():
+    """If the passed to valid_between is empty the returns (None, None)."""
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, data=np.full(len(index), np.nan))
+    assert (None, None) == gaps.valid_between(series)
+
+
+def test_valid_between_sparse_data():
+    """Check that days with only a few hours of data aren't considered
+    valid.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, data=np.full(len(index), 2.3))
+    series['01-02-2020 00:00':'01-02-2020 06:00'] = np.nan
+    series['01-02-2020 08:00':'01-02-2020 21:00'] = np.nan
+    series['07-31-2020 07:00':] = np.nan
+    start, end = gaps.valid_between(series)
+    assert start.date() == pd.Timestamp('01-03-2020').date()
+    assert end.date() == pd.Timestamp('07-30-2020').date()
+
+
+def test_valid_between_not_enough_data():
+    """Only one day of data is not ehough for any valid days."""
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, dtype='float64')
+    series['02-23-2020 08:00':'02-24-2020 08:00'] = 1
+    assert (None, None) == gaps.valid_between(series)
+
+
+def test_valid_between_one_day():
+    """Works when there is exactly the minimum number of consecutive
+    days with data.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, dtype='float64')
+    series['05-05-2020'] = 2
+    start, end = gaps.valid_between(series, days=1)
+    assert start.date() == pd.Timestamp('05-05-2020').date()
+    assert end.date() == pd.Timestamp('05-05-2020').date()
+
+
+def test_valid_between_with_gaps_in_middle():
+    """When there are gaps in the data longer than `days` valid between
+    should include those gaps, as long as there are `days` consecutive
+    days with enough data some time after the gap.
+
+    """
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, data=np.full(len(index), 1))
+    series['03-05-2020':'03-25-2020'] = np.nan
+    start, end = gaps.valid_between(series, days=5)
+    assert start.date() == index[0].date()
+    assert end.date() == index[-1].date()
+
+
+def test_trim():
+    index = pd.date_range(
+        freq='15T',
+        start='01-01-2020',
+        end='08-01-2020 23:00'
+    )
+    series = pd.Series(index=index, data=np.full(len(index), 1))
+    series['01-02-2020':'01-07-2020 13:00'] = np.nan
+    series['01-10-2020':'01-11-2020'] = np.nan
+    valid_series = gaps.trim(series, days=3)
+    assert_series_equal(
+        valid_series,
+        series['01-07-2020':'08-01-2020 00:00']
+    )

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -323,10 +323,8 @@ def test_start_stop_dates_with_gaps_in_middle():
 
 
 def test_trim_incomplete():
-    """gaps.trim_incomplete() should return a boolean mask that selects only the good
-    data in the middle of a series.
-
-    """
+    """gaps.trim_incomplete() should return a boolean mask that selects
+    only the good data in the middle of a series."""
     index = pd.date_range(
         freq='15T',
         start='01-01-2020',
@@ -342,7 +340,8 @@ def test_trim_incomplete():
 
 
 def test_trim_incomplete_empty():
-    """gaps.trim_incomplete() returns all False for series with no valid days."""
+    """gaps.trim_incomplete() returns all False for series with no valid
+    days."""
     index = pd.date_range(
         freq='15T',
         start='01-01-2020',
@@ -351,6 +350,27 @@ def test_trim_incomplete_empty():
     series = pd.Series(index=index, dtype='float64')
     series.iloc[::(24*60)] = 1
     assert (~gaps.trim_incomplete(series, days=3)).all()
+
+
+def test_trim_daily_index():
+    """trim works when data has a daily index."""
+    data = pd.Series(True, index=pd.date_range(
+        start='1/1/2020', end='3/1/2020', freq='D', closed='left'))
+    assert gaps.trim(data).all()
+    data.iloc[0:8] = False
+    data.iloc[9] = False
+    expected = data.copy()
+    expected.iloc[0:10] = False
+    assert_series_equal(
+        expected,
+        gaps.trim(data)
+    )
+    data.iloc[-5:] = False
+    expected.iloc[-5:] = False
+    assert_series_equal(
+        expected,
+        gaps.trim(data)
+    )
 
 
 def test_completeness_score_all_nans():

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -363,8 +363,7 @@ def test_trim():
     series = pd.Series(index=index, data=np.full(len(index), 1))
     series['01-02-2020':'01-07-2020 13:00'] = np.nan
     series['01-10-2020':'01-11-2020'] = np.nan
-    valid_series = gaps.trim(series, days=3)
     assert_series_equal(
-        valid_series,
+        series[gaps.trim(series, days=3)],
         series['01-07-2020':'08-01-2020 00:00']
     )

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -322,8 +322,8 @@ def test_start_stop_dates_with_gaps_in_middle():
     assert end.date() == index[-1].date()
 
 
-def test_trim():
-    """gaps.trim() should return a boolean mask that selects only the good
+def test_trim_incomplete():
+    """gaps.trim_incomplete() should return a boolean mask that selects only the good
     data in the middle of a series.
 
     """
@@ -336,13 +336,13 @@ def test_trim():
     series['01-02-2020':'01-07-2020 13:00'] = np.nan
     series['01-10-2020':'01-11-2020'] = np.nan
     assert_series_equal(
-        series[gaps.trim(series, days=3)],
+        series[gaps.trim_incomplete(series, days=3)],
         series['01-07-2020':'08-01-2020 00:00']
     )
 
 
-def test_trim_empty():
-    """gaps.trim() returns all False for series with no valid days."""
+def test_trim_incomplete_empty():
+    """gaps.trim_incomplete() returns all False for series with no valid days."""
     index = pd.date_range(
         freq='15T',
         start='01-01-2020',
@@ -350,7 +350,7 @@ def test_trim_empty():
     )
     series = pd.Series(index=index, dtype='float64')
     series.iloc[::(24*60)] = 1
-    assert (~gaps.trim(series, days=3)).all()
+    assert (~gaps.trim_incomplete(series, days=3)).all()
 
 
 def test_completeness_score_all_nans():

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -462,42 +462,42 @@ def test_daily_completeness_freq_too_high():
 
 
 def test_complete_threshold_zero():
-    """threshold of 0 returns all True regardless of data."""
+    """minimum_completeness of 0 returns all True regardless of data."""
     ten_days = pd.date_range(
         start='01/01/2020', freq='15T', end='1/10/2020', closed='left')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, threshold=0)
+        gaps.complete(data, minimum_completeness=0)
     )
     data[pd.date_range(
         start='01/01/2020', freq='1D', end='1/10/2020', closed='left')] = 1.0
     data.dropna()
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, threshold=0, freq='15T')
+        gaps.complete(data, minimum_completeness=0, freq='15T')
     )
     data = pd.Series(1.0, index=ten_days)
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, threshold=0)
+        gaps.complete(data, minimum_completeness=0)
     )
 
 
 def test_complete_threshold_one():
-    """If threshold=1 then any missing data on a day means all data for
-    the day is flagged False."""
+    """If minimum_completeness=1 then any missing data on a day means all
+    data for the day is flagged False."""
     ten_days = pd.date_range(
         start='01/01/2020', freq='15T', end='01/10/2020', closed='left')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(False, index=data.index),
-        gaps.complete(data, threshold=1.0)
+        gaps.complete(data, minimum_completeness=1.0)
     )
     data.loc[:] = 1
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, threshold=1.0)
+        gaps.complete(data, minimum_completeness=1.0)
     )
     # remove one data-point per day
     days = pd.date_range(
@@ -505,7 +505,7 @@ def test_complete_threshold_one():
     data.loc[days] = np.nan
     assert_series_equal(
         pd.Series(False, index=data.index),
-        gaps.complete(data, threshold=1.0)
+        gaps.complete(data, minimum_completeness=1.0)
     )
     # check that dropping the NaNs still gives the same result with
     # and without passing `freq`. (There should be enough data to infer the
@@ -513,11 +513,11 @@ def test_complete_threshold_one():
     data.dropna()
     assert_series_equal(
         pd.Series(False, index=data.index),
-        gaps.complete(data, threshold=1.0)
+        gaps.complete(data, minimum_completeness=1.0)
     )
     assert_series_equal(
-        gaps.complete(data, threshold=1.0),
-        gaps.complete(data, threshold=1.0, freq='15T')
+        gaps.complete(data, minimum_completeness=1.0),
+        gaps.complete(data, minimum_completeness=1.0, freq='15T')
     )
 
 
@@ -543,22 +543,22 @@ def test_complete():
     expected.loc['1/5/2020':] = True
     assert_series_equal(
         expected,
-        gaps.complete(data, threshold=1.0)
+        gaps.complete(data, minimum_completeness=1.0)
     )
 
     expected.loc['1/2/2020'] = True
     assert_series_equal(
         expected,
-        gaps.complete(data, threshold=0.5)
+        gaps.complete(data, minimum_completeness=0.5)
     )
 
     expected.loc['1/3/2020'] = True
     assert_series_equal(
         expected,
-        gaps.complete(data, threshold=0.3)
+        gaps.complete(data, minimum_completeness=0.3)
     )
 
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, threshold=0.2)
+        gaps.complete(data, minimum_completeness=0.2)
     )

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -396,7 +396,7 @@ def test_daily_completeness_all_nans():
     )
     assert_series_equal(
         pd.Series(
-            0,
+            0.0,
             index=pd.date_range(start='01/01/2020', freq='D', periods=2)
         ),
         completeness
@@ -406,12 +406,12 @@ def test_daily_completeness_all_nans():
 def test_daily_completeness_no_data():
     """A data set with completely missing timestamps and NaNs has
     completeness 0."""
-    two_days = pd.date_range(start='01/01/2020', freq='D', periods=2)
+    four_days = pd.date_range(start='01/01/2020', freq='D', periods=4)
     completeness = gaps.daily_completeness(
-        pd.Series(index=two_days, dtype='float64'), freq='15T'
+        pd.Series(index=four_days, dtype='float64'), freq='15T'
     )
     assert_series_equal(
-        pd.Series(0.0, index=two_days),
+        pd.Series(0.0, index=four_days),
         completeness
     )
 


### PR DESCRIPTION
Many data-sets come with leading and trailing periods that have sporadic or completely missing data. This adds two functions for identifying and removing these periods:
* `quality.gaps.valid_between()` gives the first and last valid dates in the series.
* `quality.gaps.trim()` returns a boolean mask that is True for the valid period between the dates given by `valid_between`.

These functions both operate on days in the data set, marking all data for each day as valid/invalid based on the number of hours of data that exists on each day. Any data point with a value other than `NaN` is considered "valid" data.