### PR TITLE
Implement daily minimum quality filtering

### DIFF
--- a/LICENSES/PVFLEETS_QA_LICENSE
+++ b/LICENSES/PVFLEETS_QA_LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,7 +86,7 @@ functions for building your own quality checks.
    :toctree: generated/
 
    quality.util.check_limits
-   quality.util.daily_maxmin
+   quality.util.daily_min
 
 Weather
 -------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -76,6 +76,18 @@ spacing, time-shifts, and time zone validation.
 
    quality.time.spacing
 
+Utilities
+---------
+
+The :py:mod:`quality.util` module contains general-purpose/utility
+functions for building your own quality checks.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.util.check_limits
+   quality.util.daily_maxmin
+
 Weather
 -------
 

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -70,13 +70,14 @@ def daily_min(series, minimum, inclusive=False):
     minimum : float
         The smallest acceptable value for the daily minimum.
     inclusive : boolean, default False
-        Use less than or equal to when comparing ``series`` to ``daily_min``.
+        Use less than or equal to when comparing daily minimums from
+        `series` to `minimum`.
 
     Returns
     -------
     Series
-        value recorded on that day is greater than (or equal to) ``minimum``.
-        all values on days where the daily minimum is >= minimum.
+        True for values on days where the minimum value recorded on
+        that day is greater than (or eaqual) `minimum`.
 
     Notes
     -----

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -58,3 +58,37 @@ def check_limits(val, lower_bound=None, upper_bound=None,
         return ub_op(val, upper_bound)
     else:
         raise ValueError('must provide either upper or lower bound')
+
+
+def daily_maxmin(series, maximum, inclusive=False):
+    """Select only data on days where the daily minimum is less than minimum.
+
+    Parameters
+    ----------
+    series : Series
+        A Datetimeindexed series of floats.
+    maximum : float
+        The largest acceptable value for the daily minumum.
+    inclusive : boolean, default False
+        Whether values equal to `maximum` are considered too large.
+
+    Returns
+    -------
+    Series
+        True for every value that occurs on a day where the minimim
+        value recorded on that day is less than `minimum`. False for
+        all values on days where the daily minimum is >= minimum.
+
+    Notes
+    -----
+    This function is derived from code in the pvfleets_qa_analysis
+    project under the terms of the 3-clause BSD license. Copyright (c)
+    2020 Alliance for Sustainable Energy, LLC.
+
+    """
+    operator = np.less
+    if inclusive:
+        operator = np.less_equal
+    dailymin = series.resample('D').min()
+    flags = operator(dailymin, maximum)
+    return flags.reindex(index=series.index, method='ffill', fill_value=False)

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -85,9 +85,9 @@ def daily_min(series, minimum, inclusive=False):
     2020 Alliance for Sustainable Energy, LLC.
 
     """
-    operator = np.greater
+    greater_than = np.greater
     if inclusive:
-        operator = np.greater_equal
+        greater_than = np.greater_equal
     dailymin = series.resample('D').min()
-    flags = operator(dailymin, minimum)
+    flags = greater_than(dailymin, minimum)
     return flags.reindex(index=series.index, method='ffill', fill_value=False)

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -70,7 +70,7 @@ def daily_min(series, minimum, inclusive=False):
     minimum : float
         The smallest acceptable value for the daily minimum.
     inclusive : boolean, default False
-        Use less than or equal to when comparing daily minimums from
+        Use greater than or equal to when comparing daily minimums from
         `series` to `minimum`.
 
     Returns

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -61,7 +61,7 @@ def check_limits(val, lower_bound=None, upper_bound=None,
 
 
 def daily_min(series, minimum, inclusive=False):
-    """Return True for data on days when the minimum exceeds `minimum`.
+    """Return True for data on days when the day's minimum exceeds `minimum`.
 
     Parameters
     ----------
@@ -77,7 +77,7 @@ def daily_min(series, minimum, inclusive=False):
     -------
     Series
         True for values on days where the minimum value recorded on
-        that day is greater than (or eaqual) `minimum`.
+        that day is greater than (or equal to) `minimum`.
 
     Notes
     -----

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -61,7 +61,7 @@ def check_limits(val, lower_bound=None, upper_bound=None,
 
 
 def daily_min(series, minimum, inclusive=False):
-    """Return True for data on days when the daily minimum is greater than (or equal to) daily_min.
+    """Return True for data on days when the minimum exceeds `minimum`.
 
     Parameters
     ----------

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -60,7 +60,7 @@ def check_limits(val, lower_bound=None, upper_bound=None,
         raise ValueError('must provide either upper or lower bound')
 
 
-def daily_maxmin(series, maximum, inclusive=False):
+def daily_min(series, minimum, inclusive=False):
     """Select only data on days where the daily minimum is less than minimum.
 
     Parameters
@@ -86,9 +86,9 @@ def daily_maxmin(series, maximum, inclusive=False):
     2020 Alliance for Sustainable Energy, LLC.
 
     """
-    operator = np.less
+    operator = np.greater
     if inclusive:
-        operator = np.less_equal
+        operator = np.greater_equal
     dailymin = series.resample('D').min()
-    flags = operator(dailymin, maximum)
+    flags = operator(dailymin, minimum)
     return flags.reindex(index=series.index, method='ffill', fill_value=False)

--- a/pvanalytics/quality/util.py
+++ b/pvanalytics/quality/util.py
@@ -61,22 +61,21 @@ def check_limits(val, lower_bound=None, upper_bound=None,
 
 
 def daily_min(series, minimum, inclusive=False):
-    """Select only data on days where the daily minimum is less than minimum.
+    """Return True for data on days when the daily minimum is greater than (or equal to) daily_min.
 
     Parameters
     ----------
     series : Series
         A Datetimeindexed series of floats.
-    maximum : float
-        The largest acceptable value for the daily minumum.
+    minimum : float
+        The smallest acceptable value for the daily minimum.
     inclusive : boolean, default False
-        Whether values equal to `maximum` are considered too large.
+        Use less than or equal to when comparing ``series`` to ``daily_min``.
 
     Returns
     -------
     Series
-        True for every value that occurs on a day where the minimim
-        value recorded on that day is less than `minimum`. False for
+        value recorded on that day is greater than (or equal to) ``minimum``.
         all values on days where the daily minimum is >= minimum.
 
     Notes

--- a/pvanalytics/tests/quality/test_util.py
+++ b/pvanalytics/tests/quality/test_util.py
@@ -55,44 +55,44 @@ def ten_days():
     )
 
 
-def test_daily_maxmin_all_below(ten_days):
+def test_daily_min_all_below(ten_days):
     """If every data point is below the minimum then all values are
-    flagged True."""
+    flagged False."""
     data = pd.Series(1, index=ten_days)
     assert_series_equal(
-        pd.Series(True, index=ten_days),
-        util.daily_maxmin(data, maximum=2)
+        pd.Series(False, index=ten_days),
+        util.daily_min(data, minimum=2)
     )
 
 
-def test_daily_maxmin_some_values_above(ten_days):
+def test_daily_min_some_values_above(ten_days):
     """If there are some values above `maximum` on one day, all data is
-    flagged True."""
+    flagged False."""
     data = pd.Series(1, index=ten_days)
     data.iloc[0:10] = 10
     data.iloc[100:150] = 10
     data.iloc[500:710] = 3
     assert_series_equal(
-        pd.Series(True, index=ten_days),
-        util.daily_maxmin(data, maximum=2)
+        pd.Series(False, index=ten_days),
+        util.daily_min(data, minimum=2)
     )
 
 
-def test_daily_maxmin_one_day_fails(ten_days):
-    """daily_maxmin flags day with all values above maximum False."""
+def test_daily_min_one_day_fails(ten_days):
+    """daily_maxmin flags day with all values above maximum True."""
     data = pd.Series(2, index=ten_days)
     data.loc['01/02/2020'] = 5
-    expected = pd.Series(True, index=ten_days)
-    expected['01/02/2020'] = False
+    expected = pd.Series(False, index=ten_days)
+    expected['01/02/2020'] = True
     assert_series_equal(
         expected,
-        util.daily_maxmin(data, maximum=3)
+        util.daily_min(data, minimum=3)
     )
 
 
-def test_daily_maxmin_exclusice(ten_days):
-    """Check that inclusive=False makes the comparison strictly less
-    than."""
+def test_daily_min_exclusice(ten_days):
+    """Check that inclusive=False makes the comparison greater than or
+    equal."""
     data = pd.Series(2, index=ten_days)
-    assert not util.daily_maxmin(data, maximum=2).any()
-    assert util.daily_maxmin(data, maximum=2, inclusive=True).all()
+    assert not util.daily_min(data, minimum=2, inclusive=False).any()
+    assert util.daily_min(data, minimum=2, inclusive=True).all()


### PR DESCRIPTION
This catches shifts in data that are apparent when the minimum value for a day is too large.

For days where the minimum value is too high all data data on that day is marked `True`. The original pvfleets function returned the opposite (that behavior can be achieved with the 'bitwise' negation of `~daily_min(...)`)