### PR TITLE
Port derivative-/quantile-based clipping detection from pvfleets QA

### DIFF
--- a/LICENSES/PVFLEETS_QA_LICENSE
+++ b/LICENSES/PVFLEETS_QA_LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -102,6 +102,7 @@ Functions for identifying inverter clipping
    :toctree: generated/
 
    features.clipping.levels
+   features.clipping.threshold
 
 Clearsky
 --------

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -102,7 +102,7 @@ def _daytime_powercurve(ac_power):
     power['positive_power'] = ac_power
     power.loc[power.positive_power >= 0, 'positive_power'] = 1
     powerfreq = power.groupby('minutes').positive_power.sum()
-    daytimes = powerfreq[powerfreq > powerfreq.quantile(0.25)].index
+    daytimes = powerfreq[powerfreq >= powerfreq.quantile(0.25)].index
     daytime_power = power[power.minutes.isin(daytimes)]
 
     return daytime_power.groupby('minutes')[power_column].quantile(0.995)

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -108,6 +108,12 @@ def _daytime_powercurve(ac_power):
     return daytime_power.groupby('minutes')[power_column].quantile(0.995)
 
 
+def _clipped(power, derivative, clip_derivative, minimum):
+    # test whether a `power` is greater than `minimum` and
+    # `derivative` is less than `clip_derivative`
+    return (np.abs(derivative) <= clip_derivative) and (power > minimum)
+
+
 def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
     # Returns the clipping power threshold or None if no clipping is
     # identified in the data.
@@ -131,7 +137,7 @@ def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
     oldpowersum = 0.0
     newpowersum = 0.0
     for derivative, power in zip(power_derivative, powercurve):
-        if ((np.abs(derivative) <= clip_derivative) and (power > power_median * 0.75)):
+        if _clipped(power, derivative, clip_derivative, power_median * 0.75):
             newcount += 1
             newpowersum += power
         else:

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -184,4 +184,4 @@ def threshold(ac_power, clip_derivative=0.0035, freq=None):
         clip_derivative=clip_derivative,
         freq=freq
     )
-    return ac_power > threshold
+    return ac_power >= threshold

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -175,24 +175,25 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
     """Detect clipping based on a maximum power threshold.
 
     This is a two-step process. First a clipping threshold is
-    identified, then any values in `ac_power` greater than or equal
-    to that threshold are flagged.
+    identified, then any values in `ac_power` greater than or equal to
+    that threshold are flagged.
 
     The clipping threshold is determined by computing a 'daily power
     curve' which is the `power_quantile` quantile of all values in
-    `ac_power` at each minute of the day (excluding night, early morning,
-    and late evening). This gives a rough estimate of the maximum power
-    produced at each minute of the day.
+    `ac_power` at each minute of the day (excluding night, early
+    morning, and late evening). This gives a rough estimate of the
+    maximum power produced at each minute of the day.
 
-    The daily power curve is normalized by its maximum and the minutes of the
-    day are identified where the normalized curve's slope is less than `slope_max`. If
-    there is a continuous period of time spanning at least one hour where
-    the slope is less than `slope_max` and the value of the normalized
-    daily power curve is greater than `power_min` times the median of the
-    normalized daily power curve then the data has clipping in it. If no
-    sufficiently long period with both a low slope and high power exists
-    then there is no clipping in the data.  The average of the daily power
-    curve (not normalized) is the clipping threshold. 
+    The daily power curve is normalized by its maximum and the minutes
+    of the day are identified where the normalized curve's slope is
+    less than `slope_max`. If there is a continuous period of time
+    spanning at least one hour where the slope is less than
+    `slope_max` and the value of the normalized daily power curve is
+    greater than `power_min` times the median of the normalized daily
+    power curve then the data has clipping in it. If no sufficiently
+    long period with both a low slope and high power exists then there
+    is no clipping in the data.  The average of the daily power curve
+    (not normalized) is the clipping threshold.
 
     Parameters
     ----------

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -169,9 +169,8 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
 
     The clipping threshold is determined by computing a 'daily power
     curve' which is the `power_quantile` quantile of all values in
-    `ac_power` at each minute of the day (excluding night, early
-    morning, and late evening). This gives a rough estimate of the
-    maximum power produced at each minute of the day.
+    `ac_power` at each minute of the day. This gives a rough estimate
+    of the maximum power produced at each minute of the day.
 
     The daily power curve is normalized by its maximum and the minutes
     of the day are identified where the normalized curve's slope is
@@ -182,7 +181,8 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
     power curve then the data has clipping in it. If no sufficiently
     long period with both a low slope and high power exists then there
     is no clipping in the data.  The average of the daily power curve
-    (not normalized) is the clipping threshold.
+    (not normalized) during the longest period that satisfies the
+    criteria above is the clipping threshold.
 
     Parameters
     ----------
@@ -207,7 +207,8 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
     Returns
     -------
     Series
-        True when clipping is indicated.
+        True when `ac_power` is greater than or equal to the clipping
+        threshold.
 
     Notes
     -----

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -162,7 +162,7 @@ def _clipping_power(ac_power, slope_max, power_min,
     # select the longest span that satisfies the clipping criteria
     longest = powercurve[clipping_cumsum == longest_clipped]
 
-    if longest.index[-1] - longest.index[0] >= 60:
+    if longest.index.max() - longest.index.min() >= 60:
         # if the period of clipping is at least 60 minutes then we
         # have enough evidence to determine the clipping threshold.
         return longest.mean()

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -112,7 +112,9 @@ def _clipped(power, derivative, clip_derivative, minimum):
     return (np.abs(derivative) <= clip_derivative) and (power > minimum)
 
 
-def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
+def _clipping_power(ac_power, clip_derivative=0.0035,
+                    power_quantile=0.995, frequency_quantile=0.25,
+                    freq=None):
     # Returns the clipping power threshold or None if no clipping is
     # identified in the data.
     #
@@ -152,7 +154,9 @@ def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
     return None
 
 
-def threshold(ac_power, clip_derivative=0.0035, freq=None):
+def threshold(ac_power, clip_derivative=0.0035,
+              power_quantile=0.995, frequency_quantile=0.25,
+              freq=None):
     """Detect clipping based on a maximum power threshold.
 
     A clipping threshold is calculated from the AC power data and any
@@ -176,6 +180,14 @@ def threshold(ac_power, clip_derivative=0.0035, freq=None):
         Minimum derivative for clipping to be indicated. The default
         value has been derived empirically to prevent false positives
         for tracking PV systems.
+    power_quantile : float, default 0.995
+        quantile used to determine the maximum power for each minute
+        of the day
+    frequency_quantile : float, default 0.25
+        After taking the count of positive values in `ac_power` at
+        each minute of the day, any minute with a count less than the
+        `frequency_quantile`-quantile of all counts is excluded from
+        the calculation of the clipping threshold.
     freq : string, default None
         A pandas string offset giving the frequency of data in
         `ac_power`. If None then the frequency is infered from the
@@ -195,6 +207,8 @@ def threshold(ac_power, clip_derivative=0.0035, freq=None):
     threshold = _clipping_power(
         ac_power,
         clip_derivative=clip_derivative,
+        power_quantile=power_quantile,
+        frequency_quantile=frequency_quantile,
         freq=freq
     )
     return ac_power >= threshold

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -106,10 +106,10 @@ def _daytime_powercurve(ac_power, power_quantile=0.995,
     ).quantile(power_quantile)
 
 
-def _clipped(power, derivative, derivative_max, minimum):
-    # test whether a `power` is greater than `minimum` and
+def _clipped(power, derivative, power_min, derivative_max):
+    # test whether a `power` is greater than `power_min` and
     # `derivative` is less than `derivative_max`
-    return (np.abs(derivative) <= derivative_max) and (power > minimum)
+    return (np.abs(derivative) <= derivative_max) and (power > power_min)
 
 
 def _clipping_power(ac_power, derivative_max=0.0035,
@@ -137,7 +137,7 @@ def _clipping_power(ac_power, derivative_max=0.0035,
     longest_powersum = 0
     longest_count = 0
     for derivative, power in zip(power_derivative, powercurve):
-        if _clipped(power, derivative, derivative_max, power_median * 0.75):
+        if _clipped(power, derivative, power_median * 0.75, derivative_max):
             count += 1
             powersum += power
         else:

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -91,8 +91,9 @@ def levels(ac_power, window=4, fraction_in_window=0.75,
 
 
 def _daytime_powercurve(ac_power, power_quantile, frequency_quantile):
-    # return the 99.5% quantile of daytime power data after removing
-    # night time data.
+    # return the `power_quantile` quantile of power at each minute of
+    # the day after removing night time, early morning, and late
+    # evening data.
     minutes = ac_power.index.hour * 60 + ac_power.index.minute
     positive_power = ac_power >= 0
     powerfreq = positive_power.groupby(minutes).sum()

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -121,7 +121,7 @@ def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
     # Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
     if not freq:
         freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds * 60
-    elif freq.isinstance(str):
+    elif isinstance(freq, str):
         freq = pd.Timedelta(freq).seconds * 60
 
     # Use the derivative of the 99.5% quantile of daytime power at

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -179,12 +179,13 @@ def threshold(ac_power, derivative_max=0.0035,
     To calculate the clipping threshold, `ac_power` is aggregated at
     each minute of the day. Low power data is removed to eliminate
     night-time periods and the 99.5% quantile is computed at each
-    minute. If the derivative of the 99.5% quantile is less than
-    `derivative_max` for a continuous period of at least one hour then
-    clipping is indicated. The mean power for that period is used as
-    the threshold. If there are multiple periods with a derivative
-    less than `derivative_max` then the longest period is used to
-    compute the threshold.
+    minute. If the absolute value of the derivative of the 99.5%
+    quantile (with respect to time) is less than `derivative_max` for
+    a continuous period of at least one hour then clipping is
+    indicated. The mean power for that period is used as the
+    threshold. If there are multiple periods with a derivative less
+    than `derivative_max` then the longest period is used to compute
+    the threshold.
 
     Parameters
     ----------

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -206,8 +206,8 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
         systems.
     power_min: float, default 0.75
         The power during periods with slope less than `slope_max` must
-        be greater than `power_min` time the median normalized daytime
-        power.
+        be greater than `power_min` times the median normalized
+        daytime power.
     power_quantile : float, default 0.995
         Quantile used to calculate the daily power curve.
     frequency_quantile : float, default 0.25

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -184,16 +184,15 @@ def threshold(ac_power, slope_max=0.0035, power_min=0.75,
     and late evening). This gives a rough estimate of the maximum power
     produced at each minute of the day.
 
-    The minutes of the day where the slope of the daily power curve,
-    normalized by its maximum, is less than `slope_max` are identified. If
+    The daily power curve is normalized by its maximum and the minutes of the
+    day are identified where the normalized curve's slope is less than `slope_max`. If
     there is a continuous period of time spanning at least one hour where
     the slope is less than `slope_max` and the value of the normalized
     daily power curve is greater than `power_min` times the median of the
-    normalized daily power curve then the data has clipping in it. The
-    average for those minutes in the (not normalized) daily power curve is
-    used as the clipping threshold. If no sufficiently long period with
-    both a low slope and high power exists then there is no clipping in
-    the data.
+    normalized daily power curve then the data has clipping in it. If no
+    sufficiently long period with both a low slope and high power exists
+    then there is no clipping in the data.  The average of the daily power
+    curve (not normalized) is the clipping threshold. 
 
     Parameters
     ----------

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -138,8 +138,7 @@ def _clipping_power(ac_power, derivative_max=0.0035, power_min=0.75,
     # power curve is greater than `power_min` times the median of the
     # daytime power curve.
     #
-    # Based on the PVFleets QA Analysis project, Copyright (c) 2020
-    # Alliance for Sustainable Energy, LLC.
+    # Based on the PVFleets QA Analysis project
     if not freq:
         freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds / 60
     elif isinstance(freq, str):
@@ -216,8 +215,7 @@ def threshold(ac_power, derivative_max=0.0035,
 
     Notes
     -----
-    This function is based on code from the pvfleets_qa_analysis
-    project. Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
+    This function is based on the pvfleets_qa_analysis project.
 
     """
     threshold = _clipping_power(

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -132,23 +132,24 @@ def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
                         / normalized_power.index.to_series().diff()) * freq
     power_median = powercurve.median()
 
-    oldcount = 0
-    newcount = 0
-    oldpowersum = 0.0
-    newpowersum = 0.0
+    powersum = 0
+    count = 0
+    longest_powersum = 0
+    longest_count = 0
     for derivative, power in zip(power_derivative, powercurve):
         if _clipped(power, derivative, clip_derivative, power_median * 0.75):
-            newcount += 1
-            newpowersum += power
+            count += 1
+            powersum += power
         else:
-            if newcount > oldcount:
-                oldcount = newcount
-                oldpowersum = newpowersum
-            newcount = 0
-            newpowersum = 0.0
+            count = 0
+            powersum = 0
 
-    if (oldcount * freq) >= 60:
-        return oldpowersum / oldcount
+        if count > longest_count:
+            longest_count = count
+            longest_powersum = powersum
+
+    if (longest_count * freq) >= 60:
+        return longest_powersum / longest_count
 
     return None
 

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -156,15 +156,23 @@ def _clipping_power(ac_power, clip_derivative=0.0035, freq=None):
 def threshold(ac_power, clip_derivative=0.0035, freq=None):
     """Detect clipping based on a maximum power threshold.
 
-    A power threshold is calculated from the AC power data and any
-    power above that threshold is assumed to be clipped. The threshold
-    is computed based on the derivative of the 99.5% quantile of all
-    power data grouped by time of day.
+    A clipping threshold is calculated from the AC power data and any
+    power greater than the threshold is flagged as clipped.
+
+    To calculate the clipping threshold, `ac_power` is aggregated at
+    each minute of the day. Low power data is removed to eliminate
+    night-time periods and the 99.5% quantile is computed. If the
+    derivative of the 99.5% quantile is less than `clip_derivative`
+    for a continuous period of at least one hour then clipping is
+    indicated. The mean power for that period is used as the
+    threshold. If there are multiple periods with a derivative less
+    than `clip_derivative` then the longest period is used to compute
+    the threshold.
 
     Parameters
     ----------
     ac_power : Series
-        Time series of AC Power.
+        DatetimeIndexed series of AC power data.
     clip_derivative : float, default 0.0035
         Minimum derivative for clipping to be indicated. The default
         value has been derived empirically to prevent false positives

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -141,9 +141,9 @@ def _clipping_power(ac_power, derivative_max=0.0035, power_min=0.75,
     # Based on the PVFleets QA Analysis project, Copyright (c) 2020
     # Alliance for Sustainable Energy, LLC.
     if not freq:
-        freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds * 60
+        freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds / 60
     elif isinstance(freq, str):
-        freq = pd.Timedelta(freq).seconds * 60
+        freq = pd.Timedelta(freq).seconds / 60
 
     # Use the derivative of the 99.5% quantile of daytime power at
     # each minute to identify clipping.

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -178,22 +178,23 @@ def threshold(ac_power, derivative_max=0.0035,
 
     To calculate the clipping threshold, `ac_power` is aggregated at
     each minute of the day. Low power data is removed to eliminate
-    night-time periods and the 99.5% quantile is computed. If the
-    derivative of the 99.5% quantile is less than `derivative_max`
-    for a continuous period of at least one hour then clipping is
-    indicated. The mean power for that period is used as the
-    threshold. If there are multiple periods with a derivative less
-    than `derivative_max` then the longest period is used to compute
-    the threshold.
+    night-time periods and the 99.5% quantile is computed at each
+    minute. If the derivative of the 99.5% quantile is less than
+    `derivative_max` for a continuous period of at least one hour then
+    clipping is indicated. The mean power for that period is used as
+    the threshold. If there are multiple periods with a derivative
+    less than `derivative_max` then the longest period is used to
+    compute the threshold.
 
     Parameters
     ----------
     ac_power : Series
         DatetimeIndexed series of AC power data.
     derivative_max : float, default 0.0035
-        Minimum derivative for clipping to be indicated. The default
-        value has been derived empirically to prevent false positives
-        for tracking PV systems.
+        Maximum absolute value of derivative of AC power quantile for
+        clipping to be indicated. The default value has been derived
+        empirically to prevent false positives for tracking PV
+        systems.
     power_quantile : float, default 0.995
         quantile used to determine the maximum power for each minute
         of the day

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -107,8 +107,9 @@ def _daytime_powercurve(ac_power, power_quantile=0.995,
 
 
 def _clipped(power, derivative, power_min, derivative_max):
-    # test whether a `power` is greater than `power_min` and
-    # `derivative` is less than `derivative_max`
+    # return a mask that is true where `power` is greater than
+    # `power_min` and the absolute value of `derivative` is less
+    # than `derivative_max`
     return (np.abs(derivative) <= derivative_max) and (power > power_min)
 
 

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -138,7 +138,8 @@ def _clipping_power(ac_power, derivative_max=0.0035, power_min=0.75,
     # power curve is greater than `power_min` times the median of the
     # daytime power curve.
     #
-    # Copyright (c) 2020 Alliance for Sustainable Energy, LLC.
+    # Based on the PVFleets QA Analysis project, Copyright (c) 2020
+    # Alliance for Sustainable Energy, LLC.
     if not freq:
         freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds * 60
     elif isinstance(freq, str):
@@ -152,8 +153,8 @@ def _clipping_power(ac_power, derivative_max=0.0035, power_min=0.75,
                         / normalized_power.index.to_series().diff()) * freq
 
     clipped_times = _clipped(powercurve, power_derivative,
-                        powercurve.median() * power_min,
-                        derivative_max)
+                             powercurve.median() * power_min,
+                             derivative_max)
     clipping_cumsum = (~clipped_times).cumsum()
     # get the value of the cumulative sum the longest True span
     longest_clipped = clipping_cumsum.value_counts().idxmax()

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -90,3 +90,21 @@ def test_threshold_clipping(quadratic_clipped):
         periods=61
     )
     assert clipping.threshold(quadratic_clipped).any()
+
+
+def test_threshold_clipping_with_night(quadratic_clipped):
+    """Clipping is identified in the daytime with periods of zero power
+    before and after simulating night time conditions."""
+    quadratic_clipped.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    full_day = quadratic_clipped.reindex(
+        pd.date_range(
+            start='01/01/2020 00:00',
+            end='01/01/2020 23:50',
+            freq='10T')
+    )
+    full_day.fillna(0)
+    assert clipping.threshold(full_day)[quadratic_clipped.index].any()

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -107,6 +107,7 @@ def test_threshold_clipping(quadratic_clipped):
         freq='10T',
         periods=61
     )
+    assert not clipping.threshold(quadratic_clipped).all()
     assert clipping.threshold(quadratic_clipped).any()
 
 
@@ -125,4 +126,5 @@ def test_threshold_clipping_with_night(quadratic_clipped):
             freq='10T')
     )
     full_day.fillna(0)
+    assert not clipping.threshold(full_day).all()
     assert clipping.threshold(full_day)[quadratic_clipped.index].any()

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -141,3 +141,20 @@ def test_threshold_clipping_with_freq(quadratic_clipped):
         clipping.threshold(quadratic_clipped),
         clipping.threshold(quadratic_clipped, freq='10T')
     )
+
+
+def test_threshold_clipping_with_interruption(quadratic_clipped):
+    """Test threshold clipping with period of no clipping mid-day."""
+    quadratic_clipped.loc[28:31] = [750, 725, 700, 650]
+    quadratic_clipped.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    clipped = clipping.threshold(quadratic_clipped)
+
+    assert not clipped.iloc[0:10].any()
+    assert not clipped.iloc[28:31].any()
+    assert not clipped.iloc[50:].any()
+    assert clipped.iloc[17:27].all()
+    assert clipped.iloc[32:40].all()

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -203,3 +203,32 @@ def test_threshold_clipping_four_days(quadratic, quadratic_clipped):
 
     assert clipped['01/01/2020'].any()
     assert not clipped['01/02/2020':].any()
+
+
+def test_threshold_no_clipping_four_days(quadratic):
+    """Four days with no clipping."""
+    quadratic.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    full_day = quadratic.reindex(
+        pd.date_range(
+            start='01/01/2020 00:00',
+            end='01/01/2020 23:50',
+            freq='10T')
+    )
+    full_day.fillna(0)
+
+    power = full_day
+    power.append(full_day * 1.3)
+    power.append(full_day * 1.2)
+    power.append(full_day * 1.1)
+
+    power.index = pd.date_range(
+        start='01/01/2020 00:00', freq='10T', periods=len(power)
+    )
+
+    clipped = clipping.threshold(power)
+
+    assert not clipped.any()

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -81,6 +81,24 @@ def test_threshold_no_clipping(quadratic):
     assert not clipping.threshold(quadratic).any()
 
 
+def test_threshold_no_clipping_with_night(quadratic):
+    """In a data set with a single quadratic surrounded by zeros there is
+    no clipping."""
+    quadratic.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    full_day = quadratic.reindex(
+        pd.date_range(
+            start='01/01/2020 00:00',
+            end='01/01/2020 23:50',
+            freq='10T')
+    )
+    full_day.fillna(0)
+    assert not clipping.threshold(quadratic).any()
+
+
 def test_threshold_clipping(quadratic_clipped):
     """In a data set with a single clipped quadratic clipping is
     indicated."""

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -128,3 +128,16 @@ def test_threshold_clipping_with_night(quadratic_clipped):
     full_day.fillna(0)
     assert not clipping.threshold(full_day).all()
     assert clipping.threshold(full_day)[quadratic_clipped.index].any()
+
+
+def test_threshold_clipping_with_freq(quadratic_clipped):
+    """Passing the frequency gives same result as infered frequency."""
+    quadratic_clipped.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    assert_series_equal(
+        clipping.threshold(quadratic_clipped),
+        clipping.threshold(quadratic_clipped, freq='10T')
+    )

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -2,6 +2,7 @@
 import pytest
 from pandas.util.testing import assert_series_equal
 import numpy as np
+import pandas as pd
 from pvanalytics.features import clipping
 
 
@@ -68,3 +69,24 @@ def test_levels_two_periods(quadratic, quadratic_clipped):
     assert clipped[35:40].all()
     assert not clipped[0:10].any()
     assert not clipped[50:].any()
+
+
+def test_threshold_no_clipping(quadratic):
+    """In a data set with a single quadratic there is no clipping."""
+    quadratic.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    assert not clipping.threshold(quadratic).any()
+
+
+def test_threshold_clipping(quadratic_clipped):
+    """In a data set with a single clipped quadratic clipping is
+    indicated."""
+    quadratic_clipped.index = pd.date_range(
+        start='01/01/2020 07:30',
+        freq='10T',
+        periods=61
+    )
+    assert clipping.threshold(quadratic_clipped).any()


### PR DESCRIPTION
Detect clipping in power data by identifying a clipping threshold (through the derivative of the 99.5% quantile of the daily power curve).

All data greater than or equal to the clipping threshold is marked as "clipped".