### PR TITLE
Optionally label every interpolated/stale point (not just endpoints)

### DIFF
--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -55,6 +55,9 @@ def stale_values_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     stale if all values in the window are close to the first value
     (index 0).
 
+    Parameters `rtol` and `atol` have the same meaning as in
+    :py:func:`numpy.allclose`.
+
     Parameters
     ----------
     x : Series
@@ -69,9 +72,6 @@ def stale_values_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     label_all : bool, default False
         Whether to label the full window. If False, then just the
         endpoints of the window are labeled.
-
-    Parameters rtol and atol have the same meaning as in
-    numpy.allclose
 
     Returns
     -------
@@ -111,6 +111,9 @@ def interpolation_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     Sequences are linear if the first difference appears to be
     constant.  For a window of length N, the last value (index N-1) is
     flagged if all values in the window appear to be a line segment.
+
+    Parameters `rtol` and `atol` have the same meaning as in
+    :py:func:`numpy.allclose`.
 
     Parameters
     ----------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -70,8 +70,8 @@ def stale_values_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     atol : float, default 1e-8
         absolute tolerance for detecting a change in data values
     label_all : bool, default False
-        Whether to label the full window. If False, then only the right
-        endpoint of the window is labeled.
+        Whether to label all values in the window. If False, then only
+        the right endpoint of the window is labeled.
 
     Returns
     -------

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -38,7 +38,7 @@ def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
 def _backfill_window(endpoints, window):
     # propagate Trues in `endpoints` back `window` periods.  This
     # makes Trues fill the entire window, rather than just marking the
-    # endpoints of the window.
+    # right endpoint of each window.
     #
     # `endpoints` must be the output of Series.rolling with `label='right'`
     flags = endpoints
@@ -70,8 +70,8 @@ def stale_values_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     atol : float, default 1e-8
         absolute tolerance for detecting a change in data values
     label_all : bool, default False
-        Whether to label the full window. If False, then just the
-        endpoints of the window are labeled.
+        Whether to label the full window. If False, then only the right
+        endpoint of the window is labeled.
 
     Returns
     -------
@@ -127,8 +127,8 @@ def interpolation_diff(x, window=3, rtol=1e-5, atol=1e-8, label_all=False):
     atol : float, default 1e-8
         absolute tolerance for detecting a change in first difference
     label_all : bool, default False
-        Whether to label all values in the window. If False only the
-        endpoints of the window are labeled.
+        Whether to label all values in the window. If False, then only the
+        right endpoint of the window is labeled.
 
     Returns
     -------

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -118,6 +118,17 @@ def test_stale_values_diff_raises_error(stale_data):
         gaps.stale_values_diff(stale_data, window=1)
 
 
+def test_stale_values_diff_label_all(stale_data):
+    """When label_all is True the full window is marked stale"""
+    assert_series_equal(
+        pd.Series([False, True, True, True, True,
+                   True, True, True, False, False]),
+        gaps.stale_values_diff(
+            stale_data, window=4, label_all=True
+        )
+    )
+
+
 @pytest.fixture
 def interpolated_data():
     """A series that contains linear interpolation.
@@ -134,6 +145,17 @@ def interpolated_data():
     data = [1.0, 1.001, 1.002001, 1.003, 1.004, 1.001001, 1.001001, 1.001001,
             1.2, 1.3, 1.5, 1.4, 1.5, 1.6, 1.7, 1.8, 2.0]
     return pd.Series(data=data)
+
+
+def test_interpolation_diff_label_all(interpolated_data):
+    """When label_all is True the full window is marked interpoated"""
+    assert_series_equal(
+        gaps.interpolation_diff(interpolated_data, window=3, label_all=True),
+        pd.Series([False, False, False, False, False,
+                   True, True, True, False, False,
+                   False, True, True, True, True, True,
+                   False])
+    )
 
 
 def test_interpolation_diff(interpolated_data):


### PR DESCRIPTION
Closes #43 

Adds kwarg `label_all` to `gaps.stale_values_diff` and `gaps.interpolation_diff`. If `label_all=True` then every point in a window that appears interpolated or stale is marked `True`. If `label_all=False` then only the endpoint of the window is marked `True`.