### PR TITLE
Set up correct import structure

### DIFF
--- a/pvanalytics/__init__.py
+++ b/pvanalytics/__init__.py
@@ -1,6 +1,6 @@
-from pvanalytics import features
-from pvanalytics import filtering
-from pvanalytics import fitting
-from pvanalytics import metrics
-from pvanalytics import quality
-from pvanalytics import system
+from pvanalytics import features   # noqa: F401
+from pvanalytics import filtering  # noqa: F401
+from pvanalytics import fitting    # noqa: F401
+from pvanalytics import metrics    # noqa: F401
+from pvanalytics import quality    # noqa: F401
+from pvanalytics import system     # noqa: F401

--- a/pvanalytics/__init__.py
+++ b/pvanalytics/__init__.py
@@ -1,0 +1,6 @@
+from pvanalytics import features
+from pvanalytics import filtering
+from pvanalytics import fitting
+from pvanalytics import metrics
+from pvanalytics import quality
+from pvanalytics import system

--- a/pvanalytics/features/__init__.py
+++ b/pvanalytics/features/__init__.py
@@ -1,2 +1,2 @@
-from pvanalytics.features import clearsky
-from pvanalytics.features import clipping
+from pvanalytics.features import clearsky  # noqa: F401
+from pvanalytics.features import clipping  # noqa: F401

--- a/pvanalytics/features/__init__.py
+++ b/pvanalytics/features/__init__.py
@@ -1,0 +1,2 @@
+from pvanalytics.features import clearsky
+from pvanalytics.features import clipping

--- a/pvanalytics/fitting/__init__.py
+++ b/pvanalytics/fitting/__init__.py
@@ -1,1 +1,1 @@
-from pvanalytics.fitting import temperature
+from pvanalytics.fitting import temperature  # noqa: F401

--- a/pvanalytics/fitting/__init__.py
+++ b/pvanalytics/fitting/__init__.py
@@ -1,0 +1,1 @@
+from pvanalytics.fitting import temperature

--- a/pvanalytics/quality/__init__.py
+++ b/pvanalytics/quality/__init__.py
@@ -1,0 +1,6 @@
+from pvanalytics.quality import gaps
+from pvanalytics.quality import util
+from pvanalytics.quality import irradiance
+from pvanalytics.quality import weather
+from pvanalytics.quality import outliers
+from pvanalytics.quality import time

--- a/pvanalytics/quality/__init__.py
+++ b/pvanalytics/quality/__init__.py
@@ -1,6 +1,6 @@
-from pvanalytics.quality import gaps
-from pvanalytics.quality import util
-from pvanalytics.quality import irradiance
-from pvanalytics.quality import weather
-from pvanalytics.quality import outliers
-from pvanalytics.quality import time
+from pvanalytics.quality import gaps        # noqa: F401
+from pvanalytics.quality import util        # noqa: F401
+from pvanalytics.quality import irradiance  # noqa: F401
+from pvanalytics.quality import weather     # noqa: F401
+from pvanalytics.quality import outliers    # noqa: F401
+from pvanalytics.quality import time        # noqa: F401


### PR DESCRIPTION
Adds import statements to `__init__.py`s so sub-modules are visible after importing their parent module. For example:

```python
from pvanalytics import quality
quality.gaps.trim_incomplete(...)
```