### PR TITLE
Expanded labeling options for functions in gaps

### DIFF
--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -51,15 +51,17 @@ def _backfill_window(endpoints, window):
     return flags
 
 
-def _label(flags, window, label):
-    if label == 'all':
+def _mark(flags, window, mark):
+    if mark not in ['all', 'tail', 'end']:
+        raise ValueError("mark must be one of 'all', 'tail', or 'end'")
+    if mark == 'all':
         return _backfill_window(flags, window)
-    if label == 'tail':
+    if mark == 'tail':
         return _backfill_window(flags, window - 1)
     return flags
 
 
-def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
+def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     """Identify stale values in the data.
 
     For a window of length N, the last value (index N-1) is considered
@@ -80,7 +82,7 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
         relative tolerance for detecting a change in data values
     atol : float, default 1e-8
         absolute tolerance for detecting a change in data values
-    label : str, default 'tail'
+    mark : str, default 'tail'
         How much of the window to mark ``True`` when a sequence of
         stale values is detected. Can be of 'tail', 'end', or 'all'.
 
@@ -100,7 +102,8 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
     Raises
     ------
     ValueError
-        If window < 2.
+        If `window < 2` or `mark` is not one of 'tail', 'all', or
+        'end'.
 
     Notes
     -----
@@ -119,10 +122,10 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
         raw=True,
         kwargs={'rtol': rtol, 'atol': atol}
     ).fillna(False).astype(bool)
-    return _label(flags, window, label)
+    return _mark(flags, window, mark)
 
 
-def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
+def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     """Identify sequences which appear to be linear.
 
     Sequences are linear if the first difference appears to be
@@ -143,7 +146,7 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
         tolerance relative to max(abs(x.diff()) for detecting a change
     atol : float, default 1e-8
         absolute tolerance for detecting a change in first difference
-    label : str, default 'tail'
+    mark : str, default 'tail'
         How much of the window to mark ``True`` when a sequence of
         interpolated values is detected. Can be 'tail', 'end', or
         'all'.
@@ -164,7 +167,8 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
     Raises
     ------
     ValueError
-        If window < 3.
+        If `window < 3` or `mark` is not one of 'tail', 'all', or
+        'end'.
 
     Notes
     -----
@@ -184,9 +188,9 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
         window=window-1,
         rtol=rtol,
         atol=atol,
-        label='end'
+        mark='end'
     )
-    return _label(flags, window, label)
+    return _mark(flags, window, mark)
 
 
 def _freq_to_seconds(freq):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -51,7 +51,15 @@ def _backfill_window(endpoints, window):
     return flags
 
 
-def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
+def _label(flags, window, label):
+    if label == 'all':
+        return _backfill_window(flags, window)
+    if label == 'tail':
+        return _backfill_window(flags, window - 1)
+    return flags
+
+
+def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
     """Identify stale values in the data.
 
     For a window of length N, the last value (index N-1) is considered
@@ -72,9 +80,17 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
         relative tolerance for detecting a change in data values
     atol : float, default 1e-8
         absolute tolerance for detecting a change in data values
-    label_all : bool, default False
-        Whether to label all values in the window. If False, then only
-        the right endpoint of the window is labeled.
+    label : str, default 'tail'
+        How much of the window to mark ``True`` when a sequence of
+        stale values is detected. Can be of 'tail', 'end', or 'all'.
+
+        - If 'tail' (the default) then every point in the window
+          *except* the first point is marked ``True``.
+        - If 'all' then every point in the window *including* the
+          first point is marked ``True``.
+        - If 'end' then only the endpoints of the window are marked
+          ``True``. The first `window - 1` values in a stale sequence
+          sequence are marked ``False``.
 
     Returns
     -------
@@ -103,12 +119,10 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
         raw=True,
         kwargs={'rtol': rtol, 'atol': atol}
     ).fillna(False).astype(bool)
-    if label_all:
-        return _backfill_window(flags, window)
-    return flags
+    return _label(flags, window, label)
 
 
-def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
+def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label='tail'):
     """Identify sequences which appear to be linear.
 
     Sequences are linear if the first difference appears to be
@@ -129,9 +143,18 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
         tolerance relative to max(abs(x.diff()) for detecting a change
     atol : float, default 1e-8
         absolute tolerance for detecting a change in first difference
-    label_all : bool, default False
-        Whether to label all values in the window. If False, then only the
-        right endpoint of the window is labeled.
+    label : str, default 'tail'
+        How much of the window to mark ``True`` when a sequence of
+        interpolated values is detected. Can be 'tail', 'end', or
+        'all'.
+
+        - If 'tail' (the default) then every point in the window
+          *except* the first point is marked ``True``.
+        - If 'all' then every point in the window *including* the
+          first point is marked ``True``.
+        - If 'end' then only the endpoints of the window are marked
+          ``True``. The first `window - 1` values in an interpolated
+          sequence are marked ``False``.
 
     Returns
     -------
@@ -160,11 +183,10 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, label_all=False):
         x.diff(periods=1),
         window=window-1,
         rtol=rtol,
-        atol=atol
+        atol=atol,
+        label='end'
     )
-    if label_all:
-        return _backfill_window(flags, window)
-    return flags
+    return _label(flags, window, label)
 
 
 def _freq_to_seconds(freq):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -53,7 +53,7 @@ def _backfill_window(endpoints, window):
 
 def _mark(flags, window, mark):
     if mark not in ['all', 'tail', 'end']:
-        raise ValueError("mark must be one of 'all', 'tail', or 'end'")
+        raise ValueError("mark must be one of'tail', 'end' or 'all'")
     if mark == 'all':
         return _backfill_window(flags, window)
     if mark == 'tail':
@@ -88,11 +88,11 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
 
         - If 'tail' (the default) then every point in the window
           *except* the first point is marked ``True``.
-        - If 'all' then every point in the window *including* the
-          first point is marked ``True``.
         - If 'end' then only the endpoints of the window are marked
           ``True``. The first `window - 1` values in a stale sequence
           sequence are marked ``False``.
+        - If 'all' then every point in the window *including* the
+          first point is marked ``True``.
 
     Returns
     -------
@@ -102,8 +102,8 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     Raises
     ------
     ValueError
-        If `window < 2` or `mark` is not one of 'tail', 'all', or
-        'end'.
+        If `window < 2` or `mark` is not one of 'tail', 'end', or
+        'all'.
 
     Notes
     -----
@@ -153,11 +153,11 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
 
         - If 'tail' (the default) then every point in the window
           *except* the first point is marked ``True``.
-        - If 'all' then every point in the window *including* the
-          first point is marked ``True``.
         - If 'end' then only the endpoints of the window are marked
           ``True``. The first `window - 1` values in an interpolated
           sequence are marked ``False``.
+        - If 'all' then every point in the window *including* the
+          first point is marked ``True``.
 
     Returns
     -------
@@ -167,8 +167,8 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     Raises
     ------
     ValueError
-        If `window < 3` or `mark` is not one of 'tail', 'all', or
-        'end'.
+        If `window < 3` or `mark` is not one of 'tail', 'end', or
+        'all'.
 
     Notes
     -----

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -52,14 +52,14 @@ def test_stale_values_diff(stale_data):
     for more information.
 
     """
-    res0 = gaps.stale_values_diff(stale_data)
-    res1 = gaps.stale_values_diff(stale_data, window=3)
-    res2 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=2)
-    res3 = gaps.stale_values_diff(stale_data, window=7)
-    res4 = gaps.stale_values_diff(stale_data, window=8)
-    res5 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=4)
-    res6 = gaps.stale_values_diff(stale_data[1:], window=3)
-    res7 = gaps.stale_values_diff(stale_data[1:8], window=3)
+    res0 = gaps.stale_values_diff(stale_data, label='end')
+    res1 = gaps.stale_values_diff(stale_data, window=3, label='end')
+    res2 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=2, label='end')
+    res3 = gaps.stale_values_diff(stale_data, window=7, label='end')
+    res4 = gaps.stale_values_diff(stale_data, window=8, label='end')
+    res5 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=4, label='end')
+    res6 = gaps.stale_values_diff(stale_data[1:], window=3, label='end')
+    res7 = gaps.stale_values_diff(stale_data[1:8], window=3, label='end')
     assert_series_equal(res0, pd.Series([False, False, False, False, False,
                                          False, True, True, False, False]))
     assert_series_equal(res1, pd.Series([False, False, False, True, True, True,
@@ -91,16 +91,22 @@ def test_stale_values_diff_handles_negatives(data_with_negatives):
     for more information.
 
     """
-    res = gaps.stale_values_diff(data_with_negatives, window=3)
+    res = gaps.stale_values_diff(data_with_negatives, window=3, label='end')
     assert_series_equal(res, pd.Series([False, False, True, True, False, False,
                                         False]))
-    res = gaps.stale_values_diff(data_with_negatives, window=3, atol=1e-3)
+    res = gaps.stale_values_diff(
+        data_with_negatives, window=3, atol=1e-3, label='end'
+    )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
-    res = gaps.stale_values_diff(data_with_negatives, window=3, atol=1e-5)
+    res = gaps.stale_values_diff(
+        data_with_negatives, window=3, atol=1e-5, label='end'
+    )
     assert_series_equal(res, pd.Series([False, False, True, True, True, False,
                                         False]))
-    res = gaps.stale_values_diff(data_with_negatives, window=3, atol=2e-5)
+    res = gaps.stale_values_diff(
+        data_with_negatives, window=3, atol=2e-5, label='end'
+    )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
 
@@ -122,13 +128,21 @@ def test_stale_values_diff_raises_error(stale_data):
 
 
 def test_stale_values_diff_label_all(stale_data):
-    """When label_all is True the full window is marked stale"""
+    """When label='all' the full window is marked stale"""
     assert_series_equal(
         pd.Series([False, True, True, True, True,
                    True, True, True, False, False]),
-        gaps.stale_values_diff(
-            stale_data, window=4, label_all=True
-        )
+        gaps.stale_values_diff(stale_data, window=4, label='all')
+    )
+
+
+def test_stale_values_diff_label_tail(stale_data):
+    """When label='tail' (the default), every point in the window except
+    the first is marked stale."""
+    assert_series_equal(
+        pd.Series([False, False, True, True, True,
+                   True, True, True, False, False]),
+        gaps.stale_values_diff(stale_data, window=4)
     )
 
 
@@ -151,12 +165,24 @@ def interpolated_data():
 
 
 def test_interpolation_diff_label_all(interpolated_data):
-    """When label_all is True the full window is marked interpoated"""
+    """When label='all' the full window is marked interpoated"""
     assert_series_equal(
-        gaps.interpolation_diff(interpolated_data, window=3, label_all=True),
+        gaps.interpolation_diff(interpolated_data, window=3, label='all'),
         pd.Series([False, False, False, False, False,
                    True, True, True, False, False,
                    False, True, True, True, True, True,
+                   False])
+    )
+
+
+def test_interpolation_diff_label_tail(interpolated_data):
+    """When label='tail' (the default), all but the first point an the
+    window is marked interpolated."""
+    assert_series_equal(
+        gaps.interpolation_diff(interpolated_data, window=3),
+        pd.Series([False, False, False, False, False,
+                   False, True, True, False, False,
+                   False, False, True, True, True, True,
                    False])
     )
 
@@ -173,27 +199,31 @@ def test_interpolation_diff(interpolated_data):
     for more information.
 
     """
-    res0 = gaps.interpolation_diff(interpolated_data)
+    res0 = gaps.interpolation_diff(interpolated_data, label='end')
     assert_series_equal(res0, pd.Series([False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False]))
-    res1 = gaps.interpolation_diff(interpolated_data, window=3)
+    res1 = gaps.interpolation_diff(interpolated_data, window=3, label='end')
     assert_series_equal(res1, pd.Series([False, False, False, False, False,
                                          False, False, True, False, False,
                                          False, False, False, True, True, True,
                                          False]))
-    res2 = gaps.interpolation_diff(interpolated_data, window=3, rtol=1e-2)
+    res2 = gaps.interpolation_diff(
+        interpolated_data, window=3, rtol=1e-2, label='end'
+    )
     assert_series_equal(res2, pd.Series([False, False, True, True, True,
                                          False, False, True, False, False,
                                          False, False, False, True, True, True,
                                          False]))
-    res3 = gaps.interpolation_diff(interpolated_data, window=5)
+    res3 = gaps.interpolation_diff(interpolated_data, window=5, label='end')
     assert_series_equal(res3, pd.Series([False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False, False, False, False,
                                          True, False]))
-    res4 = gaps.interpolation_diff(interpolated_data, window=3, atol=1e-2)
+    res4 = gaps.interpolation_diff(
+        interpolated_data, window=3, atol=1e-2, label='end'
+    )
     assert_series_equal(res4, pd.Series([False, False, True, True, True,
                                          True, True, True, False, False,
                                          False, False, False, True, True, True,
@@ -212,10 +242,14 @@ def test_interpolation_diff_handles_negatives(data_with_negatives):
     for more information.
 
     """
-    res = gaps.interpolation_diff(data_with_negatives, window=3, atol=1e-5)
+    res = gaps.interpolation_diff(
+        data_with_negatives, window=3, atol=1e-5, label='end'
+    )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         False]))
-    res = gaps.stale_values_diff(data_with_negatives, window=3, atol=1e-4)
+    res = gaps.stale_values_diff(
+        data_with_negatives, window=3, atol=1e-4, label='end'
+    )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
 
@@ -233,7 +267,7 @@ def test_interpolation_diff_raises_error(interpolated_data):
 
     """
     with pytest.raises(ValueError):
-        gaps.interpolation_diff(interpolated_data, window=2)
+        gaps.interpolation_diff(interpolated_data, window=2, label='end')
 
 
 def test_start_stop_dates_all_true():

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -52,14 +52,14 @@ def test_stale_values_diff(stale_data):
     for more information.
 
     """
-    res0 = gaps.stale_values_diff(stale_data, label='end')
-    res1 = gaps.stale_values_diff(stale_data, window=3, label='end')
-    res2 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=2, label='end')
-    res3 = gaps.stale_values_diff(stale_data, window=7, label='end')
-    res4 = gaps.stale_values_diff(stale_data, window=8, label='end')
-    res5 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=4, label='end')
-    res6 = gaps.stale_values_diff(stale_data[1:], window=3, label='end')
-    res7 = gaps.stale_values_diff(stale_data[1:8], window=3, label='end')
+    res0 = gaps.stale_values_diff(stale_data, mark='end')
+    res1 = gaps.stale_values_diff(stale_data, window=3, mark='end')
+    res2 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=2, mark='end')
+    res3 = gaps.stale_values_diff(stale_data, window=7, mark='end')
+    res4 = gaps.stale_values_diff(stale_data, window=8, mark='end')
+    res5 = gaps.stale_values_diff(stale_data, rtol=1e-8, window=4, mark='end')
+    res6 = gaps.stale_values_diff(stale_data[1:], window=3, mark='end')
+    res7 = gaps.stale_values_diff(stale_data[1:8], window=3, mark='end')
     assert_series_equal(res0, pd.Series([False, False, False, False, False,
                                          False, True, True, False, False]))
     assert_series_equal(res1, pd.Series([False, False, False, True, True, True,
@@ -91,21 +91,21 @@ def test_stale_values_diff_handles_negatives(data_with_negatives):
     for more information.
 
     """
-    res = gaps.stale_values_diff(data_with_negatives, window=3, label='end')
+    res = gaps.stale_values_diff(data_with_negatives, window=3, mark='end')
     assert_series_equal(res, pd.Series([False, False, True, True, False, False,
                                         False]))
     res = gaps.stale_values_diff(
-        data_with_negatives, window=3, atol=1e-3, label='end'
+        data_with_negatives, window=3, atol=1e-3, mark='end'
     )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
     res = gaps.stale_values_diff(
-        data_with_negatives, window=3, atol=1e-5, label='end'
+        data_with_negatives, window=3, atol=1e-5, mark='end'
     )
     assert_series_equal(res, pd.Series([False, False, True, True, True, False,
                                         False]))
     res = gaps.stale_values_diff(
-        data_with_negatives, window=3, atol=2e-5, label='end'
+        data_with_negatives, window=3, atol=2e-5, mark='end'
     )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
@@ -127,17 +127,23 @@ def test_stale_values_diff_raises_error(stale_data):
         gaps.stale_values_diff(stale_data, window=1)
 
 
-def test_stale_values_diff_label_all(stale_data):
-    """When label='all' the full window is marked stale"""
+def test_stale_values_diff_raises_error_for_bad_mark(stale_data):
+    """Passing mark not in ['all', 'end', 'tail'] raises a ValueError."""
+    with pytest.raises(ValueError):
+        gaps.stale_values_diff(stale_data, mark='head')
+
+
+def test_stale_values_diff_mark_all(stale_data):
+    """When mark='all' the full window is marked stale"""
     assert_series_equal(
         pd.Series([False, True, True, True, True,
                    True, True, True, False, False]),
-        gaps.stale_values_diff(stale_data, window=4, label='all')
+        gaps.stale_values_diff(stale_data, window=4, mark='all')
     )
 
 
-def test_stale_values_diff_label_tail(stale_data):
-    """When label='tail' (the default), every point in the window except
+def test_stale_values_diff_mark_tail(stale_data):
+    """When mark='tail' (the default), every point in the window except
     the first is marked stale."""
     assert_series_equal(
         pd.Series([False, False, True, True, True,
@@ -164,10 +170,10 @@ def interpolated_data():
     return pd.Series(data=data)
 
 
-def test_interpolation_diff_label_all(interpolated_data):
-    """When label='all' the full window is marked interpoated"""
+def test_interpolation_diff_mark_all(interpolated_data):
+    """When mark='all' the full window is marked interpoated"""
     assert_series_equal(
-        gaps.interpolation_diff(interpolated_data, window=3, label='all'),
+        gaps.interpolation_diff(interpolated_data, window=3, mark='all'),
         pd.Series([False, False, False, False, False,
                    True, True, True, False, False,
                    False, True, True, True, True, True,
@@ -175,8 +181,8 @@ def test_interpolation_diff_label_all(interpolated_data):
     )
 
 
-def test_interpolation_diff_label_tail(interpolated_data):
-    """When label='tail' (the default), all but the first point an the
+def test_interpolation_diff_mark_tail(interpolated_data):
+    """When mark='tail' (the default), all but the first point an the
     window is marked interpolated."""
     assert_series_equal(
         gaps.interpolation_diff(interpolated_data, window=3),
@@ -199,30 +205,30 @@ def test_interpolation_diff(interpolated_data):
     for more information.
 
     """
-    res0 = gaps.interpolation_diff(interpolated_data, label='end')
+    res0 = gaps.interpolation_diff(interpolated_data, mark='end')
     assert_series_equal(res0, pd.Series([False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False]))
-    res1 = gaps.interpolation_diff(interpolated_data, window=3, label='end')
+    res1 = gaps.interpolation_diff(interpolated_data, window=3, mark='end')
     assert_series_equal(res1, pd.Series([False, False, False, False, False,
                                          False, False, True, False, False,
                                          False, False, False, True, True, True,
                                          False]))
     res2 = gaps.interpolation_diff(
-        interpolated_data, window=3, rtol=1e-2, label='end'
+        interpolated_data, window=3, rtol=1e-2, mark='end'
     )
     assert_series_equal(res2, pd.Series([False, False, True, True, True,
                                          False, False, True, False, False,
                                          False, False, False, True, True, True,
                                          False]))
-    res3 = gaps.interpolation_diff(interpolated_data, window=5, label='end')
+    res3 = gaps.interpolation_diff(interpolated_data, window=5, mark='end')
     assert_series_equal(res3, pd.Series([False, False, False, False, False,
                                          False, False, False, False, False,
                                          False, False, False, False, False,
                                          True, False]))
     res4 = gaps.interpolation_diff(
-        interpolated_data, window=3, atol=1e-2, label='end'
+        interpolated_data, window=3, atol=1e-2, mark='end'
     )
     assert_series_equal(res4, pd.Series([False, False, True, True, True,
                                          True, True, True, False, False,
@@ -243,12 +249,12 @@ def test_interpolation_diff_handles_negatives(data_with_negatives):
 
     """
     res = gaps.interpolation_diff(
-        data_with_negatives, window=3, atol=1e-5, label='end'
+        data_with_negatives, window=3, atol=1e-5, mark='end'
     )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         False]))
     res = gaps.stale_values_diff(
-        data_with_negatives, window=3, atol=1e-4, label='end'
+        data_with_negatives, window=3, atol=1e-4, mark='end'
     )
     assert_series_equal(res, pd.Series([False, False, True, True, True, True,
                                         True]))
@@ -267,7 +273,13 @@ def test_interpolation_diff_raises_error(interpolated_data):
 
     """
     with pytest.raises(ValueError):
-        gaps.interpolation_diff(interpolated_data, window=2, label='end')
+        gaps.interpolation_diff(interpolated_data, window=2, mark='end')
+
+
+def test_interpolation_diff_raises_error_for_bad_mark(interpolated_data):
+    """Passing mark not in ['all', 'end', 'tail'] raises a ValueError."""
+    with pytest.raises(ValueError):
+        gaps.interpolation_diff(interpolated_data, mark='bad')
 
 
 def test_start_stop_dates_all_true():


### PR DESCRIPTION
Adds `'end'`, `'all'`, and `'tail'` to the options for labelling points in a
stale/interpolated window. Changes the default behavior to `label='tail'`
which labels every point in the window except the first.

Closes #43 