### PR TITLE
bump pytest version for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.8"
 
 install:
+  - pip install pytest==5.4.3 pytest-cov coveralls
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov coveralls
 
 script:
   - pytest --cov=pvanalytics --cov-report term-missing


### PR DESCRIPTION
Travis is having problems because the default version of pytest for
python < 3.8 is too old for the newest version of pytest-cov (2.10.0).