### PR TITLE
Daily insolation limits

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,7 +43,7 @@ eliminate data that is unrealistically high.
    quality.irradiance.clearsky_limits
 
 You may want to identify entire days that have unrealistically high or
-low irradiance. The following function examines daily insolation,
+low insolation. The following function examines daily insolation,
 validating that it is within a reasonable range of the expected
 clearsky insolation for the same day.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,14 +43,14 @@ eliminate data that is unrealistically high.
    quality.irradiance.clearsky_limits
 
 You may want to identify entire days that have unrealistically high or
-low irradiance. The following function examines summed daily
-irradiance, validating that it is within a reasonable range of the
-summed clearsky irradiance for the same day.
+low irradiance. The following function examines daily insolation,
+validating that it is within a reasonable range of the expected
+clearsky insolation for the same day.
 
 .. autosummary::
    :toctree: generated/
 
-   quality.irradiance.daily_limits
+   quality.irradiance.daily_insolation_limits
 
 Gaps
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,6 +42,16 @@ eliminate data that is unrealistically high.
 
    quality.irradiance.clearsky_limits
 
+You may want to identify entire days that have unrealistically high or
+low irradiance. The following function examines summed daily
+irradiance, validating that it is within a reasonable range of the
+summed clearsky irradiance for the same day.
+
+.. autosummary::
+   :toctree: generated/
+
+   quality.irradiance.daily_limits
+
 Gaps
 ----
 

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -417,10 +417,12 @@ def _daily_total(series):
             integrate.trapz,
             dx=freq_hours
         )
-    df = series.to_frame(name='value')
-    df['hour'] = (series.index.minute / 60) + series.index.hour
-    return df.resample('D').apply(
-        lambda day: integrate.trapz(y=day['value'], x=day['hour'])
+    hours = pd.Series(
+        (series.index.minute / 60) + series.index.hour,
+        index=series.index
+    )
+    return series.resample('D').apply(
+        lambda day: integrate.trapz(y=day, x=hours[day.index])
     )
 
 

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -400,8 +400,14 @@ def _to_hours(freqstr):
 
 
 def _daily_total(series):
+    # Resample the series returning the integral for each day.
+    #
+    # Assumes that timestamps are evenly spaced and uses the Trapezoid
+    # rule for integration.
     freq_hours = _to_hours(pd.infer_freq(series.index))
-    return series.resample('D').sum() * freq_hours
+    return series.resample('D').apply(
+        lambda day: freq_hours * (day[:-1] + day[1:]).sum()
+    )
 
 
 def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -410,7 +410,7 @@ def _daily_total(series):
     )
 
 
-def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
+def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     """Check that daily insolation lies between minimum and maximum values.
 
     Irradiance measurements and clear-sky irradiance on each day are

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -407,8 +407,8 @@ def _daily_total(series):
 def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     """Check that daily insolation lies between minimum and maximum values.
 
-    Irradiance measurements and clear-sky irradiance on each day are integrated with the
-    left-hand rule to calculate daily insolation.
+    Irradiance measurements and clear-sky irradiance on each day are
+    integrated with the left-hand rule to calculate daily insolation.
 
     .. note::
 
@@ -432,8 +432,8 @@ def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     Returns
     -------
     Series
-        True for values on days where the ratio of daily insolation to daily clearsky insolation is between `daily_min`
-        and `daily_max`.
+        True for values on days where the ratio of daily insolation to
+        daily clearsky insolation is between `daily_min` and `daily_max`.
 
     Notes
     -----

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -442,9 +442,9 @@ def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
 
     """
     daily_irradiance = _daily_total(irrad)
-    daily_cleasky = _daily_total(clearsky)
+    daily_clearsky = _daily_total(clearsky)
     good_days = util.check_limits(
-        daily_irradiance/daily_cleasky,
+        daily_irradiance/daily_clearsky,
         upper_bound=daily_max,
         lower_bound=daily_min
     )

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -451,13 +451,13 @@ def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
 
     Notes
     -----
-    The default values for `daily_min` and `daily_max` were taken from
-    the PVFleets QA Analysis project.
-
     The default limits (`daily_max` and `daily_min`) have been set for
     GHI and POA irradiance for systems with *fixed* azimuth and tilt.
     If you pass POA irradiance for a tracking system it is recommended
     that you increase `daily_max` to 1.35.
+
+    The default values for `daily_min` and `daily_max` were taken from
+    the PVFleets QA Analysis project.
 
     """
     daily_irradiance = _daily_total(irrad)

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -410,13 +410,6 @@ def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     Irradiance measurements and clear-sky irradiance on each day are
     integrated with the left-hand rule to calculate daily insolation.
 
-    .. note::
-
-       This has been built to work on GHI and POA for both
-       tracking and fixed PV systems; however, if testing POA irradiance
-       for a tracking system it is recommended that you increase
-       `daily_max` to 1.35.
-
     Parameters
     ----------
     irrad : Series
@@ -439,6 +432,10 @@ def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     -----
     The default values for `daily_min` and `daily_max` were taken from
     the PVFleets QA Analysis project.
+
+    The default limits (`daily_max` and `daily_min`) have been set for
+    GHI. If you pass POA it is recommended that you increase
+    `daily_max` to 1.35.
 
     """
     daily_irradiance = _daily_total(irrad)

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -456,7 +456,7 @@ def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     the PVFleets QA Analysis project.
 
     The default limits (`daily_max` and `daily_min`) have been set for
-    GHI and POA irradiance for systems with *fixed* azimuth and tilt. 
+    GHI and POA irradiance for systems with *fixed* azimuth and tilt.
     If you pass POA irradiance for a tracking system it is recommended
     that you increase `daily_max` to 1.35.
 

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -405,13 +405,10 @@ def _daily_total(series):
 
 
 def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
-    """Check that daily total irradiance is near the total clearsky irradiance.
+    """Check that daily insolation lies between minimum and maximum values.
 
-    Irradiance measurements on each day are integrated with the
-    left-hand rule and the total is compared to the total clearsky
-    irradiance for each day. If the ratio of total irradiance to total
-    clearsky is less than or equal to `daily_min` or greater than or
-    equal to `daily_max` then values on the day are marked False.
+    Irradiance measurements and clear-sky irradiance on each day are integrated with the
+    left-hand rule to calculate daily insolation.
 
     .. note::
 
@@ -430,14 +427,12 @@ def daily_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
         Minimum ratio of daily total irradiance to daily total
         clearsky irradiance.
     daily_max : float, default 1.25
-        Maximum ratio of daily total irradiance to daily total
-        clearsky irradiance.
+        Maximum ratio of daily insolation to daily clearsky insolation.
 
     Returns
     -------
     Series
-        True for values on days where the ratio of total measured
-        irradiance to total clearsky irradiance is between `daily_min`
+        True for values on days where the ratio of daily insolation to daily clearsky insolation is between `daily_min`
         and `daily_max`.
 
     Notes

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -456,8 +456,9 @@ def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     the PVFleets QA Analysis project.
 
     The default limits (`daily_max` and `daily_min`) have been set for
-    GHI. If you pass POA it is recommended that you increase
-    `daily_max` to 1.35.
+    GHI and POA irradiance for systems with *fixed* azimuth and tilt. 
+    If you pass POA irradiance for a tracking system it is recommended
+    that you increase `daily_max` to 1.35.
 
     """
     daily_irradiance = _daily_total(irrad)

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -430,17 +430,16 @@ def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     """Check that daily insolation lies between minimum and maximum values.
 
     Irradiance measurements and clear-sky irradiance on each day are
-    integrated with the left-hand rule to calculate daily insolation.
+    integrated with the trapezoid rule to calculate daily insolation.
 
     Parameters
     ----------
     irrad : Series
         Irradiance measurements (GHI or POA).
     clearsky : Series
-        Expected clearsky irradiance.
+        Clearsky irradiance.
     daily_min : float, default 0.4
-        Minimum ratio of daily total irradiance to daily total
-        clearsky irradiance.
+        Minimum ratio of daily insolation to daily clearsky insolation.
     daily_max : float, default 1.25
         Maximum ratio of daily insolation to daily clearsky insolation.
 

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -257,7 +257,7 @@ def test_clearsky_limits_csi_max(times):
     )
 
 
-def test_daily_limits_nrel():
+def test_daily_insolation_limits_nrel():
     """"""
     three_days = pd.date_range(
         start='1/1/2020',
@@ -272,8 +272,10 @@ def test_daily_limits_nrel():
         tz='MST'
     )
     clearsky = albuquerque.get_clearsky(three_days, model='simplified_solis')
-    assert irradiance.daily_limits(clearsky['ghi'], clearsky['ghi']).all()
-    assert not irradiance.daily_limits(
+    assert irradiance.daily_insolation_limits(
+        clearsky['ghi'], clearsky['ghi']
+    ).all()
+    assert not irradiance.daily_insolation_limits(
         pd.Series(0, index=three_days),
         clearsky['ghi']
     ).any()
@@ -285,6 +287,6 @@ def test_daily_limits_nrel():
     expected.loc['1/1/2020'] = True
     assert_series_equal(
         expected,
-        irradiance.daily_limits(irrad, clearsky['ghi']),
+        irradiance.daily_insolation_limits(irrad, clearsky['ghi']),
         check_names=False
     )


### PR DESCRIPTION
Identify days where the total irradiance is too high or too low. This catches incorrectly labeled sensors (e.g. labeled GHI, but actually POA) or days with strange shifts (for example I saw a data set where the units change from Watts to Milliwatts for a week or two). Existing functions might also catch these, but the aggregate daily check seems like a worthwhile addition to me.