### PR TITLE
Refactor curve fitting functions

### DIFF
--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -8,7 +8,7 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
     # Return the :math:`r^2` of a curve fit to a single day of data if
     # certain conditions are met.
     #
-    # `fitfunc` does the curve fitting and is only applied if two 
+    # `fitfunc` does the curve fitting and is only applied if two
     # conditions are met:
     # - There must be more than `min_hours` of data in `day`
     #   (determined by the number of values in `day` times `freq`).
@@ -23,7 +23,7 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
     # day : Series
     #     y-values to which `fitfunc` will be applied.
     # minutes : Series
-    #     x-values for curve fitting. The index for `x` must be a 
+    #     x-values for curve fitting. The index for `x` must be a
     #     superset of the index for `day`.
     # fitfunc : function
     #     Function to perform curve fit. Must accept two parameters,

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -3,7 +3,7 @@ import pandas as pd
 from pvanalytics.util import _fit, _group
 
 
-def _conditional_fit(day, fitfunc, minutes, freq, default=0.0, min_hours=0.0,
+def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
                      peak_min=None):
     # Fit a curve to a single day of data if certain conditions are met.
     #
@@ -17,12 +17,12 @@ def _conditional_fit(day, fitfunc, minutes, freq, default=0.0, min_hours=0.0,
     # ----------
     # day : Series
     #     y-values to which `fitfunc` will be applied.
-    # fitfunc : function
-    #     Function to perform curve fit. Must accept two parameters,
-    #     the x-values and y-values
     # minutes : Series
     #     x-values for curve fitting. Must have an index that is a
     #     superset of the index of `day`.
+    # fitfunc : function
+    #     Function to perform curve fit. Must accept two parameters,
+    #     the x-values and y-values
     # freq : str
     #     Timestamp spacing for data in `day`.
     # default : float, default 0.0
@@ -146,7 +146,7 @@ def tracking_nrel(power_or_irradiance, daytime, r2_min=0.915,
     daily_data = _group.by_day(power_or_irradiance[daytime])
     tracking_days = daily_data.apply(
         _conditional_fit,
-        _fit.quartic_restricted,
+        fitfunc=_fit.quartic_restricted,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,
@@ -154,7 +154,7 @@ def tracking_nrel(power_or_irradiance, daytime, r2_min=0.915,
     )
     fixed_days = _group.by_day(power_or_irradiance[quadratic_mask]).apply(
         _conditional_fit,
-        _fit.quadratic,
+        fitfunc=_fit.quadratic,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,
@@ -219,7 +219,7 @@ def fixed_nrel(power_or_irradiance, daytime, r2_min=0.94,
     )
     fixed_days = daily_data.apply(
         _conditional_fit,
-        _fit.quadratic,
+        fitfunc=_fit.quadratic,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -5,13 +5,17 @@ from pvanalytics.util import _fit, _group
 
 def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
                      peak_min=None):
-    # Fit a curve to a single day of data if certain conditions are met.
+    # Return the :math:`r^2` of a curve fit to a single day of data if
+    # certain conditions are met.
     #
-    # For the fit to proceed there must be more than `min_hours` of
-    # data in `day` (determined by the number of values in `day` times
-    # `freq`). Additionally, if `peak_min` is specified then no curve
-    # fitting will be performed if the maximum value in `day` is less
-    # than `peak_min`. If no fit is performed the `default` is returned.
+    # `fitfunc` is only applied if two conditions are met:
+    # - There must be more than `min_hours` of data in `day`
+    #   (determined by the number of values in `day` times `freq`).
+    # - If `peak_min` is specified then no curve fitting will be
+    #   performed unless the maximum value in `day` is at least
+    #   `peak_min`.
+    #
+    # If either condition is not satisfied then `default` is returned.
     #
     # Parameters
     # ----------

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -8,7 +8,8 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
     # Return the :math:`r^2` of a curve fit to a single day of data if
     # certain conditions are met.
     #
-    # `fitfunc` is only applied if two conditions are met:
+    # `fitfunc` does the curve fitting and is only applied if two 
+    # conditions are met:
     # - There must be more than `min_hours` of data in `day`
     #   (determined by the number of values in `day` times `freq`).
     # - If `peak_min` is specified then no curve fitting will be
@@ -22,18 +23,19 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
     # day : Series
     #     y-values to which `fitfunc` will be applied.
     # minutes : Series
-    #     x-values for curve fitting. Must have an index that is a
-    #     superset of the index of `day`.
+    #     x-values for curve fitting. The index for `x` must be a 
+    #     superset of the index for `day`.
     # fitfunc : function
     #     Function to perform curve fit. Must accept two parameters,
-    #     the x-values and y-values
+    #     the x-values and y-values, and return the :math:`r^2`
+    #     of the curve fit.
     # freq : str
     #     Timestamp spacing for data in `day`.
     # default : float, default 0.0
     #     Value to be returned if the conditions above are not
     #     satisfied and `fitfunc` is not applied.
     # min_hours : float, default 0.0
-    #     Minimum hours with data for curve fitting to be performed.
+    #     Minimum hours in `day` with data for curve fitting to be performed.
     # peak_min : float or None, default None
     #     Maximum value in `day` must be at least `peak_min` for curve
     #     fitting to be performed.

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -5,12 +5,40 @@ from pvanalytics.util import _fit, _group
 
 def _conditional_fit(day, fitfunc, minutes, freq, default=0.0, min_hours=0.0,
                      peak_min=None):
-    # If there are at least `min_hours` of data in `day` and the
-    # maximum for the day is greater than `peak_min` then `fitfunc` is
-    # applied to fit a curve to the data. `fitfunc` must be a function
-    # that takes a Series and returns the :math:`r^2` for a curve fit.
-    # If the two conditions are not met then `default` is returned and
-    # no curve fitting is performed.
+    # Fit a curve to a single day of data if certain conditions are met.
+    #
+    # For the fit to proceed there must be more than `min_hours` of
+    # data in `day` (determined by the number of values in `day` times
+    # `freq`). Additionally, if `peak_min` is specified then no curve
+    # fitting will be performed if the maximum value in `day` is less
+    # than `peak_min`. If no fit is performed the `default` is returned.
+    #
+    # Parameters
+    # ----------
+    # day : Series
+    #     y-values to which `fitfunc` will be applied.
+    # fitfunc : function
+    #     Function to perform curve fit. Must accept two parameters,
+    #     the x-values and y-values
+    # minutes : Series
+    #     x-values for curve fitting. Must have an index that is a
+    #     superset of the index of `day`.
+    # freq : str
+    #     Timestamp spacing for data in `day`.
+    # default : float, default 0.0
+    #     Value to be returned if the conditions above are not
+    #     satisfied and `fitfunc` is not applied.
+    # min_hours : float, default 0.0
+    #     Minimum hours with data for curve fitting to be performed.
+    # peak_min : float or None, default None
+    #     Maximum value in `day` must be at least `peak_min` for curve
+    #     fitting to be performed.
+    #
+    # Returns
+    # -------
+    # float
+    #     The :math:`r^2` of the curve fit from `fitfunc` or `default`
+    #     if fit was not performed.
     high_enough = True
     if peak_min is not None:
         high_enough = day.max() > peak_min

--- a/pvanalytics/tests/util/test_fit.py
+++ b/pvanalytics/tests/util/test_fit.py
@@ -1,9 +1,0 @@
-"""Tests for curve fitting functions"""
-import pytest
-from pvanalytics.util import _fit
-
-
-def test_fit_not_datetime_raises_error(quadratic):
-    """Trying to fit to an integer index raises a ValueError."""
-    with pytest.raises(ValueError):
-        _fit.quadratic(quadratic)

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -8,7 +8,7 @@ def quadratic(x, y):
 
     Parameters
     ----------
-    x : Series
+    x : array_like
         x values for data in `y`.
     y : Series
         data to which the curve should be fit.
@@ -59,7 +59,7 @@ def quartic_restricted(x, y, noon=720):
 
     Parameters
     ----------
-    x : Series
+    x : array_like
         x values for data in `y`
     y : Series
         values to which the curve should be fit

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -1,7 +1,6 @@
 """Internal module for curve fitting functions."""
 import numpy as np
 import scipy.optimize
-import pandas as pd
 
 
 def quadratic(x, y):

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -37,10 +37,8 @@ def quadratic(x, y):
     Alliance for Sustainable Energy, LLC.
 
     """
-    # Fit a quadratic to `data` returning R^2 for the fit.
     coefficients = np.polyfit(x, y, 2)
     quadratic = np.poly1d(coefficients)
-    # Calculate the R^2 for the fit
     _, _, correlation, _, _ = scipy.stats.linregress(
         y, quadratic(x)
     )

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -18,6 +18,19 @@ def quadratic(x, y):
     float
         The :math:`R^2` value for the fit.
 
+    Examples
+    --------
+    This function is typically used for fitting a function to power or
+    irradiance data. In this case the irradiance measurements are
+    passed as `y` and the time of day for each value, in minutes since
+    midnight, is passed as `x`. Suppose ``ghi`` below is a time series
+    with one day of GHI measurements:
+
+    >>> r2 = quadratic(
+    ...     y=ghi
+    ...     x=ghi.index.minute + ghi.index.hour * 60,
+    ... )
+
     Notes
     -----
     Based on the PVFleets QA Analysis project. Copyright (c) 2020
@@ -59,6 +72,19 @@ def quartic_restricted(x, y, noon=720):
     -------
     rsquared : float
         The :math:`R^2` value for the fit.
+
+    Examples
+    --------
+    This function is typically used for fitting a function to power or
+    irradiance data. In this case the irradiance measurements are
+    passed as `y` and the time of day for each value, in minutes since
+    midnight, is passed as `x`. Suppose ``poa`` below is a time series
+    with one day of POA irradiance measurements:
+
+    >>> r2 = quartic_restricted(
+    ...     y=poa
+    ...     x=poa.index.minute + poa.index.hour * 60,
+    ... )
 
     Notes
     -----

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -4,23 +4,15 @@ import scipy.optimize
 import pandas as pd
 
 
-def _to_minute_of_day(index):
-    # Transform the index into minutes of the day. If `index` is a
-    # DatetimeIndex then it is converted to an Int64Index with values
-    # equal to the minute of the day since midnight. Any other type
-    # and a ValueError is raised.
-    if isinstance(index, pd.DatetimeIndex):
-        return index.hour * 60 + index.minute
-    raise ValueError("cannot convert index to minutes since midnight")
-
-
-def quadratic(data):
+def quadratic(x, y):
     """Fit a quadratic to the data.
 
     Parameters
     ----------
-    data : Series
-        Series of power or irradiance measurements.
+    x : Series
+        x values for data in `y`.
+    y : Series
+        data to which the curve should be fit.
 
     Reurns
     ------
@@ -33,18 +25,17 @@ def quadratic(data):
     Alliance for Sustainable Energy, LLC.
 
     """
-    minute_of_day = _to_minute_of_day(data.index)
     # Fit a quadratic to `data` returning R^2 for the fit.
-    coefficients = np.polyfit(minute_of_day, data, 2)
+    coefficients = np.polyfit(x, y, 2)
     quadratic = np.poly1d(coefficients)
     # Calculate the R^2 for the fit
     _, _, correlation, _, _ = scipy.stats.linregress(
-        data, quadratic(minute_of_day)
+        y, quadratic(x)
     )
     return correlation**2
 
 
-def quartic_restricted(data, noon=720):
+def quartic_restricted(x, y, noon=720):
     """Fit a restricted quartic to the data.
 
     The quartic is restricted to match the expected shape for a
@@ -58,8 +49,10 @@ def quartic_restricted(data, noon=720):
 
     Parameters
     ----------
-    data : Series
-        power or irradiance data.
+    x : Series
+        x values for data in `y`
+    y : Series
+        values to which the curve should be fit
     noon : int, default 720
        The minute for solar noon. Defaults to the clock-noon.
 
@@ -76,14 +69,13 @@ def quartic_restricted(data, noon=720):
     """
     def _quartic(x, a, b, c, e):
         return a * (x - e)**4 + b * (x - e)**2 + c
-    minute_of_day = _to_minute_of_day(data.index)
-    median = data.median()
+    median = y.median()
     params, _ = scipy.optimize.curve_fit(
         _quartic,
-        minute_of_day, data,
+        x, y,
         bounds=((-1e-05, 0, median * 0.85, noon - 70),
                 (-1e-10, median * 3e-05, median * 1.15, noon + 70))
     )
-    model = _quartic(minute_of_day, params[0], params[1], params[2], params[3])
-    residuals = data - model
-    return 1 - (np.sum(residuals**2) / np.sum((data - np.mean(data))**2))
+    model = _quartic(x, params[0], params[1], params[2], params[3])
+    residuals = y - model
+    return 1 - (np.sum(residuals**2) / np.sum((y - np.mean(y))**2))


### PR DESCRIPTION
Since these functions are used in a `pandas.GroupBy.apply()` call, manipulating the index to calculate minute of the day can significantly reduce performance. Here we remove the `_get_minute_of_day()` function and instead pass in the x values as a parameter. In addition to improving performance this makes the curve fitting code cleaner and substantially more general.