### PR TITLE
Infer azimuth and tilt from power or POA irradiance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -210,3 +210,14 @@ identification.
 
    features.orientation.fixed_nrel
    features.orientation.tracking_nrel
+
+System
+======
+
+The following function can be used to infer system orientation from
+power or plane of array irradiance measurements.
+
+.. autosummary::
+   :toctree: generated/
+
+   system.infer_orientation_least_squares

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -220,4 +220,4 @@ power or plane of array irradiance measurements.
 .. autosummary::
    :toctree: generated/
 
-   system.infer_orientation_least_squares
+   system.infer_orientation_daily_peak

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -152,7 +152,7 @@ def tracking_nrel(power_or_irradiance, daytime, r2_min=0.915,
     daily_data = _group.by_day(power_or_irradiance[daytime])
     tracking_days = daily_data.apply(
         _conditional_fit,
-        fitfunc=_fit.quartic_restricted,
+        fitfunc=_fit.quartic_restricted_r2,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,
@@ -160,7 +160,7 @@ def tracking_nrel(power_or_irradiance, daytime, r2_min=0.915,
     )
     fixed_days = _group.by_day(power_or_irradiance[quadratic_mask]).apply(
         _conditional_fit,
-        fitfunc=_fit.quadratic,
+        fitfunc=_fit.quadratic_r2,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,
@@ -225,7 +225,7 @@ def fixed_nrel(power_or_irradiance, daytime, r2_min=0.94,
     )
     fixed_days = daily_data.apply(
         _conditional_fit,
-        fitfunc=_fit.quadratic,
+        fitfunc=_fit.quadratic_r2,
         minutes=minutes,
         freq=freq,
         min_hours=min_hours,

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -56,8 +56,8 @@ def infer_orientation_least_squares(power_or_poa, daytime, tilts,
     power_or_poa : Series
         Timezone localized series of power or POA irradiance
         measurements.
-    sunny : Series
-        Boolean series with True for values when it is sunny.
+    daytime : Series
+        Boolean series with True for values when it is daytime.
     tilts : list of floats
         List of candidate tilts.
     azimuths : list of floats

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -29,6 +29,27 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
                 solar_azimuth, solar_zenith, ghi, dhi, dni):
     """Determine system azimuth and tilt from power or POA.
 
+    Solar noon is estimated on each day by fitting a quadratic to data
+    in `power_or_poa` and finding the vertex of the fit. A brute force
+    search is performed on clearsky POA irradiance for all pairs of
+    candidate azimuths and tilts (`azimuths` and `tilts`) to find the
+    pair that results in the closest azimuth at solar noon to the
+    azimuths calculated from the curve fitting step. Closest is
+    determined by minimizing the sum of squared error between the
+    azimuth at solar noon on each day in `power_or_poa` and the
+    azimuth at solar noon (maximum POA) in the clearsky POA
+    irradiance.
+
+    The accuracy of the values returned from this function will vary
+    with the time-resolution of the clearsky and solar position
+    data. For the best accuracy pass `solar_azimuth`, `solar_zenith`,
+    and the clearsky data (`ghi`, `dhi`, and `dni`) with one-minute
+    timestamp spacing. If `solar_azimuth` has timestamp spacing less
+    than one minute it will be resampled and interpolated to estimate
+    azimuth at each minute of the day. Regardless of the timestamp
+    spacing these parameters must cover the same days as
+    `power_or_poa`.
+
     Parameters
     ----------
     power_or_poa : Series
@@ -37,9 +58,9 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
     sunny : Series
         Boolean series with True for values when it is sunny.
     tilts : list of floats
-        list of tilts to check
+        List of candidate tilts.
     azimuths : list of floats
-        list of azimuths
+        List of candidate azimuths.
     solar_azimuth : Series
         Time series of solar azimuth.
     solar_zenith : Series
@@ -55,6 +76,10 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
     -------
     azimuth : float
     tilt : float
+
+    Notes
+    -----
+    Based on PVFleets QA project.
 
     """
     peak_times = _peak_times(power_or_poa[daytime])

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -77,7 +77,7 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
                 dni=dni
             ).poa_global
             poa_azimuths = azimuth_by_minute[
-                _peak_times(poa[solar_zenith < 70])
+                _group.by_day(poa).idxmax()
             ]
             filtered_azimuths = poa_azimuths[np.isin(
                 poa_azimuths.index.date,

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -28,7 +28,7 @@ def _peak_times(data):
 def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
                                 azimuths, solar_azimuth,
                                 solar_zenith, ghi, dhi, dni):
-    """Determine system azimuth and tilt from power or POA using apparent
+    """Determine system azimuth and tilt from power or POA using inferred
     solar noon.
 
     Solar noon is estimated on each day by fitting a quadratic to data

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -35,9 +35,9 @@ def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
     in `power_or_poa` and finding the vertex of the fit. A brute force
     search is performed on clearsky POA irradiance for all pairs of
     candidate azimuths and tilts (`azimuths` and `tilts`) to find the
-    pair that results in the closest azimuth at solar noon to the
-    azimuths calculated from the curve fitting step. Closest is
-    determined by minimizing the sum of squared error between the
+    pair that results in the closest azimuth to the
+    azimuths calculated at solar noon  from the curve fitting step. Closest is
+    determined by minimizing the sum of squared difference between the
     solar azimuth at solar noon on each day in `power_or_poa` and the
     solar azimuth at maximum clearsky POA irradiance.
 

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -58,10 +58,10 @@ def infer_orientation_least_squares(power_or_poa, daytime, tilts,
         measurements.
     daytime : Series
         Boolean series with True for values when it is daytime.
-    tilts : list of floats
-        List of candidate tilts.
-    azimuths : list of floats
-        List of candidate azimuths.
+    tilts : array-like
+        Candidate tilts in degrees.
+    azimuths : array-like
+        Candidate azimuths in degrees.
     solar_azimuth : Series
         Time series of solar azimuth.
     solar_zenith : Series

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -51,10 +51,8 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
 
     """
     peak_times = _peak_times(power_or_poa[daytime])
-    modeled_azimuth = solar_azimuth.reindex(
-        peak_times,
-        method='bfill'
-    )
+    azimuth_by_minute = solar_azimuth.resample('T').interpolate(method='linear')
+    modeled_azimuth = azimuth_by_minute[peak_times]
     best_azimuth = None
     best_tilt = None
     smallest_sse = None
@@ -69,10 +67,9 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
                 dhi=dhi,
                 dni=dni
             ).poa_global
-            poa_azimuths = solar_azimuth.reindex(
-                _peak_times(poa[solar_zenith < 70]),
-                method='bfill'
-            )
+            poa_azimuths = azimuth_by_minute[
+                _peak_times(poa[solar_zenith < 70])
+            ]
             sum_of_squares = sum(
                 (poa_azimuths.values - modeled_azimuth.values)**2
             )

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -5,8 +5,15 @@ from pvanalytics.util import _fit, _group
 
 
 def _peak_times(data):
+    minute_of_day = pd.Series(
+        data.index.hour * 60 + data.index.minute,
+        index=data.index
+    )
     return pd.DatetimeIndex(
-        _group.by_day(data).apply(_fit.quadratic_idxmax),
+        _group.by_day(data).apply(
+            _fit.quadratic_idxmax,
+            minutes=minute_of_day
+        ),
         tz=data.index.tz
     )
 

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -25,7 +25,7 @@ def _peak_times(data):
     ) + peak_minutes
 
 
-def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
+def infer_orientation_solarnoon(power_or_poa, sunny, tilts,
                                 azimuths, solar_azimuth,
                                 solar_zenith, ghi, dhi, dni):
     """Determine system azimuth and tilt from power or POA using inferred
@@ -56,8 +56,9 @@ def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
     power_or_poa : Series
         Timezone localized series of power or POA irradiance
         measurements.
-    daytime : Series
-        Boolean series with True for values when it is daytime.
+    sunny : Series
+        Boolean series with True for values during clearsky
+        conditions.
     tilts : array-like
         Candidate tilts in degrees.
     azimuths : array-like
@@ -83,7 +84,7 @@ def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
     Based on PVFleets QA project.
 
     """
-    peak_times = _peak_times(power_or_poa[daytime])
+    peak_times = _peak_times(power_or_poa[sunny])
     azimuth_by_minute = solar_azimuth.resample('T').interpolate(
         method='linear'
     )

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -26,21 +26,22 @@ def _peak_times(data):
     ) + peak_minutes
 
 
-def infer_orientation_solarnoon(power_or_poa, sunny, tilts,
-                                azimuths, solar_azimuth,
-                                solar_zenith, ghi, dhi, dni):
-    """Determine system azimuth and tilt from power or POA using inferred
-    solar noon.
+def infer_orientation_daily_peak(power_or_poa, sunny, tilts,
+                                 azimuths, solar_azimuth,
+                                 solar_zenith, ghi, dhi, dni):
+    """Determine system azimuth and tilt from power or POA using solar
+    azimuth at the daily peak.
 
-    Solar noon is estimated on each day by fitting a quadratic to data
-    in `power_or_poa` and finding the vertex of the fit. A brute force
-    search is performed on clearsky POA irradiance for all pairs of
-    candidate azimuths and tilts (`azimuths` and `tilts`) to find the
-    pair that results in the closest azimuth to the
-    azimuths calculated at solar noon  from the curve fitting step. Closest is
-    determined by minimizing the sum of squared difference between the
-    solar azimuth at solar noon on each day in `power_or_poa` and the
-    solar azimuth at maximum clearsky POA irradiance.
+    The time of the daily peak is estimated by fitting a quadratic to
+    to the data for each day in `power_or_poa` and finding the vertex
+    of the fit. A brute force search is performed on clearsky POA
+    irradiance for all pairs of candidate azimuths and tilts
+    (`azimuths` and `tilts`) to find the pair that results in the
+    closest azimuth to the azimuths calculated at the peak times from
+    the curve fitting step. Closest is determined by minimizing the
+    sum of squared difference between the solar azimuth at the peak
+    time in `power_or_poa` and the solar azimuth at maximum clearsky
+    POA irradiance.
 
     The accuracy of the tilt and azimuth returned by this function will
     vary with the time-resolution of the clearsky and solar position

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -51,7 +51,9 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
 
     """
     peak_times = _peak_times(power_or_poa[daytime])
-    azimuth_by_minute = solar_azimuth.resample('T').interpolate(method='linear')
+    azimuth_by_minute = solar_azimuth.resample('T').interpolate(
+        method='linear'
+    )
     modeled_azimuth = azimuth_by_minute[peak_times]
     best_azimuth = None
     best_tilt = None

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -80,7 +80,8 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
                 _peak_times(poa[solar_zenith < 70])
             ]
             sum_of_squares = sum(
-                (poa_azimuths.values - modeled_azimuth.values)**2
+                (poa_azimuths[modeled_azimuth.index].values
+                 - modeled_azimuth.values)**2
             )
             if (smallest_sse is None) or (smallest_sse > sum_of_squares):
                 smallest_sse = sum_of_squares

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -79,9 +79,12 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
             poa_azimuths = azimuth_by_minute[
                 _peak_times(poa[solar_zenith < 70])
             ]
+            filtered_azimuths = poa_azimuths[np.isin(
+                poa_azimuths.index.date,
+                modeled_azimuth.index.date
+            )]
             sum_of_squares = sum(
-                (poa_azimuths[modeled_azimuth.index].values
-                 - modeled_azimuth.values)**2
+                (filtered_azimuths.values - modeled_azimuth.values)**2
             )
             if (smallest_sse is None) or (smallest_sse > sum_of_squares):
                 smallest_sse = sum_of_squares

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -36,12 +36,11 @@ def orientation(power_or_poa, daytime, tilts, azimuths,
     pair that results in the closest azimuth at solar noon to the
     azimuths calculated from the curve fitting step. Closest is
     determined by minimizing the sum of squared error between the
-    azimuth at solar noon on each day in `power_or_poa` and the
-    azimuth at solar noon (maximum POA) in the clearsky POA
-    irradiance.
+    solar azimuth at solar noon on each day in `power_or_poa` and the
+    solar azimuth at maximum clearsky POA irradiance.
 
-    The accuracy of the values returned from this function will vary
-    with the time-resolution of the clearsky and solar position
+    The accuracy of the tilt and azimuth returned by this function will
+    vary with the time-resolution of the clearsky and solar position
     data. For the best accuracy pass `solar_azimuth`, `solar_zenith`,
     and the clearsky data (`ghi`, `dhi`, and `dni`) with one-minute
     timestamp spacing. If `solar_azimuth` has timestamp spacing less

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -25,11 +25,11 @@ def _peak_times(data):
     ) + peak_minutes
 
 
-def infer_orientation_least_squares(power_or_poa, daytime, tilts,
-                                    azimuths, solar_azimuth,
-                                    solar_zenith, ghi, dhi, dni):
-    """Determine system azimuth and tilt from power or POA using least
-    squares.
+def infer_orientation_solarnoon(power_or_poa, daytime, tilts,
+                                azimuths, solar_azimuth,
+                                solar_zenith, ghi, dhi, dni):
+    """Determine system azimuth and tilt from power or POA using apparent
+    solar noon.
 
     Solar noon is estimated on each day by fitting a quadratic to data
     in `power_or_poa` and finding the vertex of the fit. A brute force

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -25,9 +25,11 @@ def _peak_times(data):
     ) + peak_minutes
 
 
-def orientation(power_or_poa, daytime, tilts, azimuths,
-                solar_azimuth, solar_zenith, ghi, dhi, dni):
-    """Determine system azimuth and tilt from power or POA.
+def infer_orientation_least_squares(power_or_poa, daytime, tilts,
+                                    azimuths, solar_azimuth,
+                                    solar_zenith, ghi, dhi, dni):
+    """Determine system azimuth and tilt from power or POA using least
+    squares.
 
     Solar noon is estimated on each day by fitting a quadratic to data
     in `power_or_poa` and finding the vertex of the fit. A brute force

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -1,1 +1,76 @@
 """Functions for identifying system characteristics."""
+import pandas as pd
+import pvlib
+from pvanalytics.util import _fit, _group
+
+
+def _peak_times(data):
+    return pd.DatetimeIndex(
+        _group.by_day(data).apply(_fit.quadratic_idxmax),
+        tz=data.index.tz
+    )
+
+
+def orientation(power_or_poa, daytime, tilts, azimuths,
+                solar_azimuth, solar_zenith, ghi, dhi, dni):
+    """Determine system azimuth and tilt from power or POA.
+
+    Parameters
+    ----------
+    power_or_poa : Series
+        Timezone localized series of power or POA irradiance
+        measurements.
+    sunny : Series
+        Boolean series with True for values when it is sunny.
+    tilts : list of floats
+        list of tilts to check
+    azimuths : list of floats
+        list of azimuths
+    solar_azimuth : Series
+        Time series of solar azimuth.
+    solar_zenith : Series
+        Time series of solar zenith.
+    ghi : Series
+        Clear sky GHI.
+    dhi : Series
+        Clear sky DHI.
+    dni : Series
+        Clear sky DNI.
+
+    Returns
+    -------
+    azimuth : float
+    tilt : float
+
+    """
+    peak_times = _peak_times(power_or_poa[daytime])
+    modeled_azimuth = solar_azimuth.reindex(
+        peak_times,
+        method='bfill'
+    )
+    best_azimuth = None
+    best_tilt = None
+    smallest_sse = None
+    for azimuth in azimuths:
+        for tilt in tilts:
+            poa = pvlib.irradiance.get_total_irradiance(
+                tilt,
+                azimuth,
+                solar_zenith,
+                solar_azimuth,
+                ghi=ghi,
+                dhi=dhi,
+                dni=dni
+            ).poa_global
+            poa_azimuths = solar_azimuth.reindex(
+                _peak_times(poa[solar_zenith < 70]),
+                method='bfill'
+            )
+            sum_of_squares = sum(
+                (poa_azimuths.values - modeled_azimuth.values)**2
+            )
+            if (smallest_sse is None) or (smallest_sse > sum_of_squares):
+                smallest_sse = sum_of_squares
+                best_azimuth = azimuth
+                best_tilt = tilt
+    return best_azimuth, best_tilt

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -12,10 +12,11 @@ def _peak_times(data):
     )
     peak_minutes = _group.by_day(data).apply(
         lambda day: pd.Timedelta(
-            minutes=_fit.quadratic_idxmax(
-                x=minute_of_day[day.index],
-                y=day,
-                model_range=range(0, 1440)
+            minutes=round(
+                _fit.quadratic_vertex(
+                    x=minute_of_day[day.index],
+                    y=day,
+                )
             )
         )
     )

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -17,6 +17,17 @@ def quadratic():
 
 
 @pytest.fixture(scope='module')
+def one_year_hourly():
+    return pd.date_range(
+        start='03/01/2020',
+        end='03/01/2021',
+        closed='left',
+        freq='H',
+        tz='Etc/GMT+7'
+    )
+
+
+@pytest.fixture(scope='module')
 def three_days_hourly():
     """Three days with one hour timestamp spacing in Etc/GMT+7"""
     return pd.date_range(
@@ -53,3 +64,18 @@ def clearsky(three_days_hourly, albuquerque):
 def solarposition(three_days_hourly, albuquerque):
     """Solar position at `three_days_hourly` in `albuquerque`."""
     return albuquerque.get_solarposition(three_days_hourly)
+
+
+@pytest.fixture(scope='module')
+def clearsky_year(one_year_hourly, albuquerque):
+    """One year of hourly clearsky data."""
+    return albuquerque.get_clearsky(
+        one_year_hourly,
+        model='simplified_solis'
+    )
+
+
+@pytest.fixture(scope='module')
+def solarposition_year(one_year_hourly, albuquerque):
+    """One year of solar position data in albuquerque"""
+    return albuquerque.get_solarposition(one_year_hourly)

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 import pandas as pd
+from pvlib import location
 
 
 @pytest.fixture
@@ -13,3 +14,42 @@ def quadratic():
     """
     q = -1000 * (np.linspace(-1, 1, 61) ** 2) + 1000
     return pd.Series(q)
+
+
+@pytest.fixture(scope='module')
+def three_days_hourly():
+    """Three days with one hour timestamp spacing in Etc/GMT+7"""
+    return pd.date_range(
+        start='03/01/2020',
+        end='03/04/2020',
+        closed='left',
+        freq='H',
+        tz='Etc/GMT+7'
+    )
+
+
+@pytest.fixture(scope='module')
+def albuquerque():
+    """pvlib Location for Albuquerque, NM."""
+    return location.Location(
+        35.0844,
+        -106.6504,
+        name='Albuquerque',
+        altitude=1500,
+        tx='Etc/GMT+7'
+    )
+
+
+@pytest.fixture(scope='module')
+def clearsky(three_days_hourly, albuquerque):
+    """Clearsky at `three_days_hourly` in `albuquerque`."""
+    return albuquerque.get_clearsky(
+        three_days_hourly,
+        model='simplified_solis'
+    )
+
+
+@pytest.fixture(scope='module')
+def solarposition(three_days_hourly, albuquerque):
+    """Solar position at `three_days_hourly` in `albuquerque`."""
+    return albuquerque.get_solarposition(three_days_hourly)

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -7,30 +7,6 @@ from pvanalytics.features import orientation
 
 
 @pytest.fixture(scope='module')
-def times():
-    """Three days with one hour timestamp spacing in Etc/GMT+7"""
-    return pd.date_range(
-        start='03/01/2020',
-        end='03/04/2020',
-        closed='left',
-        freq='H',
-        tz='Etc/GMT+7'
-    )
-
-
-@pytest.fixture(scope='module')
-def albuquerque():
-    """pvlib Location for Albuquerque, NM."""
-    return location.Location(
-        35.0844,
-        -106.6504,
-        name='Albuquerque',
-        altitude=1500,
-        tx='Etc/GMT+7'
-    )
-
-
-@pytest.fixture(scope='module')
 def system_parameters():
     """System parameters for generating simulated power data."""
     sandia_modules = pvsystem.retrieve_sam('SandiaMod')
@@ -45,18 +21,6 @@ def system_parameters():
         'inverter_parameters': inverter,
         'temperature_model_parameters': temperature_model_parameters
     }
-
-
-@pytest.fixture(scope='module')
-def clearsky(times, albuquerque):
-    """Clearsky at `times` in `albuquerque`."""
-    return albuquerque.get_clearsky(times, model='simplified_solis')
-
-
-@pytest.fixture(scope='module')
-def solarposition(times, albuquerque):
-    """Solar position at `times` in `albuquerque`."""
-    return albuquerque.get_solarposition(times)
 
 
 def test_clearsky_ghi_fixed(clearsky, solarposition):

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -1,7 +1,7 @@
 import pytest
 from pandas.util.testing import assert_series_equal
 import pandas as pd
-from pvlib import location, pvsystem, tracking, modelchain, irradiance
+from pvlib import pvsystem, tracking, modelchain, irradiance
 from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
 from pvanalytics.features import orientation
 

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -4,11 +4,6 @@ from pvlib import irradiance
 from pvanalytics import system
 
 
-def _assert_within(x, expected, margin):
-    # test that x is in the range [expected - margin, expected + margin]
-    assert x in range(expected - margin, expected + margin + 1)
-
-
 def test_simple_poa_orientation(clearsky_year, solarposition_year):
     poa = irradiance.get_total_irradiance(
         surface_tilt=15,
@@ -19,15 +14,15 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year):
     )
     azimuth, tilt = system.orientation(
         poa['poa_global'],
-        tilts=range(5, 25, 5),
-        azimuths=range(150, 200, 5),
+        tilts=[15, 30],
+        azimuths=[110, 180, 220],
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         **clearsky_year
     )
-    _assert_within(azimuth, 180, 10)
-    _assert_within(tilt, 15, 10)
+    assert azimuth == 180
+    assert tilt == 15
 
 
 def test_ghi_tilt_zero(clearsky_year, solarposition_year):
@@ -35,7 +30,7 @@ def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     _, tilt = system.orientation(
         clearsky_year['ghi'],
         daytime=solarposition_year['apparent_zenith'] < 87,
-        tilts=[0, 2, 4],
+        tilts=[0, 5],
         azimuths=[180],
         solar_azimuth=solarposition_year['azimuth'],
         solar_zenith=solarposition_year['zenith'],
@@ -69,9 +64,9 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
         poa['poa_global'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         tilts=[40],
-        azimuths=range(105, 135, 5),
+        azimuths=[100, 120, 150],
         solar_azimuth=fine_solarposition['azimuth'],
         solar_zenith=fine_solarposition['apparent_zenith'],
         **fine_clearsky,
     )
-    _assert_within(azimuth, 120, 10)
+    assert azimuth == 120

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -41,7 +41,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.orientation(
+    azimuth, tilt = system.infer_orientation_least_squares(
         poa['poa_global'],
         tilts=[15, 30],
         azimuths=[110, 180, 220],
@@ -56,7 +56,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
 
 def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     """ghi has tilt equal to 0"""
-    _, tilt = system.orientation(
+    _, tilt = system.infer_orientation_least_squares(
         clearsky_year['ghi'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         tilts=[0, 5],
@@ -79,7 +79,7 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.orientation(
+    azimuth, tilt = system.infer_orientation_least_squares(
         poa['poa_global'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         tilts=[40],
@@ -100,7 +100,7 @@ def test_orientation_with_gaps(clearsky_year, solarposition_year):
         solar_azimuth=solarposition_year['azimuth']
     )
     poa.loc['2020-07-19':'2020-07-23'] = np.nan
-    azimuth, tilt = system.orientation(
+    azimuth, tilt = system.infer_orientation_least_squares(
         poa['poa_global'].dropna(),
         tilts=[15],
         azimuths=[180],

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -44,7 +44,8 @@ def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     assert tilt == 0
 
 
-def test_azimuth_different_index(clearsky_year, solarposition_year, albuquerque):
+def test_azimuth_different_index(clearsky_year, solarposition_year,
+                                 albuquerque):
     """Can use solar position and clearsky with finer time-resolution to
     get an accurate estimate of tilt and azimuth."""
     poa = irradiance.get_total_irradiance(

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -41,7 +41,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.infer_orientation_least_squares(
+    azimuth, tilt = system.infer_orientation_solarnoon(
         poa['poa_global'],
         tilts=[15, 30],
         azimuths=[110, 180, 220],
@@ -56,7 +56,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
 
 def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     """ghi has tilt equal to 0"""
-    _, tilt = system.infer_orientation_least_squares(
+    _, tilt = system.infer_orientation_solarnoon(
         clearsky_year['ghi'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         tilts=[0, 5],
@@ -79,7 +79,7 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.infer_orientation_least_squares(
+    azimuth, tilt = system.infer_orientation_solarnoon(
         poa['poa_global'],
         daytime=solarposition_year['apparent_zenith'] < 87,
         tilts=[40],
@@ -100,7 +100,7 @@ def test_orientation_with_gaps(clearsky_year, solarposition_year):
         solar_azimuth=solarposition_year['azimuth']
     )
     poa.loc['2020-07-19':'2020-07-23'] = np.nan
-    azimuth, tilt = system.infer_orientation_least_squares(
+    azimuth, tilt = system.infer_orientation_solarnoon(
         poa['poa_global'].dropna(),
         tilts=[15],
         azimuths=[180],

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -82,7 +82,6 @@ def test_orientation_with_gaps(clearsky_year, solarposition_year):
         solar_azimuth=solarposition_year['azimuth']
     )
     poa.loc['2020-07-19':'2020-07-23'] = np.nan
-    print(f"{poa['poa_global'].dropna().dtype}")
     azimuth, tilt = system.orientation(
         poa['poa_global'].dropna(),
         tilts=[15],

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -4,6 +4,11 @@ from pvlib import irradiance
 from pvanalytics import system
 
 
+def _assert_within(x, expected, margin):
+    # test that x is within range(expected + margin, expected - margin)
+    assert x in range(expected - margin, expected + margin)
+
+
 def test_simple_poa_orientation(clearsky_year, solarposition_year):
     poa = irradiance.get_total_irradiance(
         surface_tilt=15,
@@ -21,12 +26,8 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year):
         daytime=solarposition_year['apparent_zenith'] < 87,
         **clearsky_year
     )
-    # May not get the exact azimuth, but it should be within 10
-    # degrees of 180
-    assert 170 < azimuth < 190
-    # We should get the exact tilt since it is one of the candidates
-    # we pass in to the function
-    assert tilt == 15
+    _assert_within(azimuth, 180, 10)
+    _assert_within(tilt, 15, 10)
 
 
 def test_ghi_tilt_zero(clearsky_year, solarposition_year):
@@ -34,7 +35,7 @@ def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     _, tilt = system.orientation(
         clearsky_year['ghi'],
         daytime=solarposition_year['apparent_zenith'] < 87,
-        tilts=[0, 2, 4, 6, 8, 10],
+        tilts=[0, 2, 4],
         azimuths=[180],
         solar_azimuth=solarposition_year['azimuth'],
         solar_zenith=solarposition_year['zenith'],
@@ -66,11 +67,11 @@ def test_azimuth_different_index(clearsky_year, solarposition_year, albuquerque)
     azimuth, tilt = system.orientation(
         poa['poa_global'],
         daytime=solarposition_year['apparent_zenith'] < 87,
-        tilts=range(20, 50, 5),
-        azimuths=range(100, 150, 5),
+        tilts=range(25, 60, 5),
+        azimuths=range(105, 135, 5),
         solar_azimuth=fine_solarposition['azimuth'],
         solar_zenith=fine_solarposition['apparent_zenith'],
         **fine_clearsky,
     )
-    assert azimuth == 120
-    assert tilt == 40
+    _assert_within(azimuth, 120, 10)
+    _assert_within(tilt, 40, 10)

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -5,8 +5,8 @@ from pvanalytics import system
 
 
 def _assert_within(x, expected, margin):
-    # test that x is within range(expected + margin, expected - margin)
-    assert x in range(expected - margin, expected + margin)
+    # test that x is in the range [expected - margin, expected + margin]
+    assert x in range(expected - margin, expected + margin + 1)
 
 
 def test_simple_poa_orientation(clearsky_year, solarposition_year):

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -41,7 +41,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.infer_orientation_solarnoon(
+    azimuth, tilt = system.infer_orientation_daily_peak(
         poa['poa_global'],
         tilts=[15, 30],
         azimuths=[110, 180, 220],
@@ -56,7 +56,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
 
 def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     """ghi has tilt equal to 0"""
-    _, tilt = system.infer_orientation_solarnoon(
+    _, tilt = system.infer_orientation_daily_peak(
         clearsky_year['ghi'],
         sunny=solarposition_year['apparent_zenith'] < 87,
         tilts=[0, 5],
@@ -79,7 +79,7 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth']
     )
-    azimuth, tilt = system.infer_orientation_solarnoon(
+    azimuth, tilt = system.infer_orientation_daily_peak(
         poa['poa_global'],
         sunny=solarposition_year['apparent_zenith'] < 87,
         tilts=[40],
@@ -100,7 +100,7 @@ def test_orientation_with_gaps(clearsky_year, solarposition_year):
         solar_azimuth=solarposition_year['azimuth']
     )
     poa.loc['2020-07-19':'2020-07-23'] = np.nan
-    azimuth, tilt = system.infer_orientation_solarnoon(
+    azimuth, tilt = system.infer_orientation_daily_peak(
         poa['poa_global'].dropna(),
         tilts=[15],
         azimuths=[180],

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -68,11 +68,10 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
     azimuth, tilt = system.orientation(
         poa['poa_global'],
         daytime=solarposition_year['apparent_zenith'] < 87,
-        tilts=range(25, 60, 5),
+        tilts=[40],
         azimuths=range(105, 135, 5),
         solar_azimuth=fine_solarposition['azimuth'],
         solar_zenith=fine_solarposition['apparent_zenith'],
         **fine_clearsky,
     )
     _assert_within(azimuth, 120, 10)
-    _assert_within(tilt, 40, 10)

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -1,0 +1,76 @@
+"""Tests for system paramter identification functions."""
+import pandas as pd
+from pvlib import irradiance
+from pvanalytics import system
+
+
+def test_simple_poa_orientation(clearsky_year, solarposition_year):
+    poa = irradiance.get_total_irradiance(
+        surface_tilt=15,
+        surface_azimuth=180,
+        **clearsky_year,
+        solar_zenith=solarposition_year['apparent_zenith'],
+        solar_azimuth=solarposition_year['azimuth']
+    )
+    azimuth, tilt = system.orientation(
+        poa['poa_global'],
+        tilts=range(5, 25, 5),
+        azimuths=range(150, 200, 5),
+        solar_zenith=solarposition_year['apparent_zenith'],
+        solar_azimuth=solarposition_year['azimuth'],
+        daytime=solarposition_year['apparent_zenith'] < 87,
+        **clearsky_year
+    )
+    # May not get the exact azimuth, but it should be within 10
+    # degrees of 180
+    assert 170 < azimuth < 190
+    # We should get the exact tilt since it is one of the candidates
+    # we pass in to the function
+    assert tilt == 15
+
+
+def test_ghi_tilt_zero(clearsky_year, solarposition_year):
+    """ghi has tilt equal to 0"""
+    _, tilt = system.orientation(
+        clearsky_year['ghi'],
+        daytime=solarposition_year['apparent_zenith'] < 87,
+        tilts=[0, 2, 4, 6, 8, 10],
+        azimuths=[180],
+        solar_azimuth=solarposition_year['azimuth'],
+        solar_zenith=solarposition_year['zenith'],
+        **clearsky_year
+    )
+    assert tilt == 0
+
+
+def test_azimuth_different_index(clearsky_year, solarposition_year, albuquerque):
+    """Can use solar position and clearsky with finer time-resolution to
+    get an accurate estimate of tilt and azimuth."""
+    poa = irradiance.get_total_irradiance(
+        surface_tilt=40,
+        surface_azimuth=120,
+        **clearsky_year,
+        solar_zenith=solarposition_year['apparent_zenith'],
+        solar_azimuth=solarposition_year['azimuth']
+    )
+    fine_index = pd.date_range(
+        start=clearsky_year.index.min(),
+        end=clearsky_year.index.max(),
+        freq='1T'
+    )
+    fine_solarposition = albuquerque.get_solarposition(fine_index)
+    fine_clearsky = albuquerque.get_clearsky(
+        fine_index,
+        model='simplified_solis'
+    )
+    azimuth, tilt = system.orientation(
+        poa['poa_global'],
+        daytime=solarposition_year['apparent_zenith'] < 87,
+        tilts=range(20, 50, 5),
+        azimuths=range(100, 150, 5),
+        solar_azimuth=fine_solarposition['azimuth'],
+        solar_zenith=fine_solarposition['apparent_zenith'],
+        **fine_clearsky,
+    )
+    assert azimuth == 120
+    assert tilt == 40

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -47,7 +47,7 @@ def test_simple_poa_orientation(clearsky_year, solarposition_year,
         azimuths=[110, 180, 220],
         solar_zenith=fine_solarposition['apparent_zenith'],
         solar_azimuth=fine_solarposition['azimuth'],
-        daytime=solarposition_year['apparent_zenith'] < 87,
+        sunny=solarposition_year['apparent_zenith'] < 87,
         **fine_clearsky
     )
     assert azimuth == 180
@@ -58,7 +58,7 @@ def test_ghi_tilt_zero(clearsky_year, solarposition_year):
     """ghi has tilt equal to 0"""
     _, tilt = system.infer_orientation_solarnoon(
         clearsky_year['ghi'],
-        daytime=solarposition_year['apparent_zenith'] < 87,
+        sunny=solarposition_year['apparent_zenith'] < 87,
         tilts=[0, 5],
         azimuths=[180],
         solar_azimuth=solarposition_year['azimuth'],
@@ -81,7 +81,7 @@ def test_azimuth_different_index(clearsky_year, solarposition_year,
     )
     azimuth, tilt = system.infer_orientation_solarnoon(
         poa['poa_global'],
-        daytime=solarposition_year['apparent_zenith'] < 87,
+        sunny=solarposition_year['apparent_zenith'] < 87,
         tilts=[40],
         azimuths=[100, 120, 150],
         solar_azimuth=fine_solarposition['azimuth'],
@@ -106,7 +106,7 @@ def test_orientation_with_gaps(clearsky_year, solarposition_year):
         azimuths=[180],
         solar_zenith=solarposition_year['apparent_zenith'],
         solar_azimuth=solarposition_year['azimuth'],
-        daytime=solarposition_year['apparent_zenith'] < 87,
+        sunny=solarposition_year['apparent_zenith'] < 87,
         **clearsky_year
     )
     assert azimuth == 180

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -10,7 +10,7 @@ def _quadratic(xs, ys):
 
 
 def quadratic_idxmax(x, y, model_range=None):
-    """Fit a quartic to the data and return the x-value of the vertex.
+    """Fit a quadratic to the x, y data and return the x-value of the vertex.
 
     Parameters
     ----------

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -1,6 +1,5 @@
 """Internal module for curve fitting functions."""
 import numpy as np
-import pandas as pd
 import scipy.optimize
 
 
@@ -10,14 +9,28 @@ def _quadratic(xs, ys):
     return np.poly1d(coefficients)
 
 
-def quadratic_idxmax(data, minutes):
-    """Fit a quartic to the data returning the time where the vertex falls."""
-    quadratic = _quadratic(minutes[data.index], data)
-    model = quadratic(range(0, 1440))
-    return (
-        pd.Timestamp(data.index.min().date(), tz=data.index.tz)
-        + pd.Timedelta(minutes=np.argmax(model))
-    )
+def quadratic_idxmax(x, y, model_range=None):
+    """Fit a quartic to the data and return the x-value of the vertex.
+
+    Parameters
+    ----------
+    x : array_like
+    y : Series
+        x and y-values to fit to.
+    model_range : array_like, optional
+        Range of values to find the max in. If not specified then `x`
+        is used.
+
+    Returns
+    -------
+    numeric
+        x-value of the vertex of a quadratic fit to the data in `x`
+        and `y`.
+    """
+    model_range = model_range or x
+    quadratic = _quadratic(x, y)
+    model = quadratic(model_range)
+    return model_range[np.argmax(model)]
 
 
 def quadratic(x, y):

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -16,7 +16,6 @@ def quadratic_idxmax(x, y, model_range=None):
     ----------
     x : array_like
     y : Series
-        x and y-values to fit to.
     model_range : array_like, optional
         Range of x-values to find the max over. If not specified then
         `x` is used.

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -1,6 +1,23 @@
 """Internal module for curve fitting functions."""
 import numpy as np
+import pandas as pd
 import scipy.optimize
+
+
+def _quadratic(xs, ys):
+    # fit a quadratic function of `xs` to the data in `ys`
+    coefficients = np.polyfit(xs, ys, 2)
+    return np.poly1d(coefficients)
+
+
+def quadratic_idxmax(data):
+    """Fit a quartic to the data returning the time where the vertex falls."""
+    quadratic = _quadratic(_to_minute_of_day(data.index), data)
+    model = quadratic(range(0, 1440))
+    return (
+        pd.Timestamp(data.index.min().date())
+        + pd.Timedelta(minutes=np.argmax(model))
+    )
 
 
 def quadratic(x, y):
@@ -37,8 +54,7 @@ def quadratic(x, y):
     Alliance for Sustainable Energy, LLC.
 
     """
-    coefficients = np.polyfit(x, y, 2)
-    quadratic = np.poly1d(coefficients)
+    quadratic = _quadratic(x, y)
     _, _, correlation, _, _ = scipy.stats.linregress(
         y, quadratic(x)
     )

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -15,7 +15,7 @@ def quadratic_idxmax(data):
     quadratic = _quadratic(_to_minute_of_day(data.index), data)
     model = quadratic(range(0, 1440))
     return (
-        pd.Timestamp(data.index.min().date())
+        pd.Timestamp(data.index.min().date(), tz=data.index.tz)
         + pd.Timedelta(minutes=np.argmax(model))
     )
 

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -18,8 +18,8 @@ def quadratic_idxmax(x, y, model_range=None):
     y : Series
         x and y-values to fit to.
     model_range : array_like, optional
-        Range of values to find the max in. If not specified then `x`
-        is used.
+        Range of x-values to find the max over. If not specified then
+        `x` is used.
 
     Returns
     -------

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -26,6 +26,19 @@ def quadratic_idxmax(x, y, model_range=None):
     numeric
         x-value of the vertex of a quadratic fit to the data in `x`
         and `y`.
+
+    Examples
+    --------
+    >>> quadratic_idxmax(x=[-2, -1, 2, 4], y=[-4, -1, -4, -16])
+    -1
+
+    >>> quadratic_idxmax(
+    ...     x=[-2, -1, 2, 4],
+    ...     y=[-4, -1, -4, -16],
+    ...     model_range=[-4, -3, -2, -1, 0, 1, 2, 3, 4]
+    ... )
+    0
+
     """
     model_range = model_range or x
     quadratic = _quadratic(x, y)

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -41,8 +41,8 @@ def quadratic_idxmax(x, y, model_range=None):
 
     """
     model_range = model_range or x
-    quadratic = _quadratic(x, y)
-    model = quadratic(model_range)
+    q = _quadratic(x, y)
+    model = q(model_range)
     return model_range[np.argmax(model)]
 
 

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -46,8 +46,8 @@ def quadratic_idxmax(x, y, model_range=None):
     return model_range[np.argmax(model)]
 
 
-def quadratic(x, y):
-    """Fit a quadratic to the data.
+def quadratic_r2(x, y):
+    """Return the r^2 for a quadratic fit the the data.
 
     Parameters
     ----------
@@ -87,8 +87,8 @@ def quadratic(x, y):
     return correlation**2
 
 
-def quartic_restricted(x, y, noon=720):
-    """Fit a restricted quartic to the data.
+def quartic_restricted_r2(x, y, noon=720):
+    """Return the r^2 for a restricted quartic fit to the data.
 
     The quartic is restricted to match the expected shape for a
     tracking pv system under clearsky conditions. The quartic must:

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -10,9 +10,9 @@ def _quadratic(xs, ys):
     return np.poly1d(coefficients)
 
 
-def quadratic_idxmax(data):
+def quadratic_idxmax(data, minutes):
     """Fit a quartic to the data returning the time where the vertex falls."""
-    quadratic = _quadratic(_to_minute_of_day(data.index), data)
+    quadratic = _quadratic(minutes[data.index], data)
     model = quadratic(range(0, 1440))
     return (
         pd.Timestamp(data.index.min().date(), tz=data.index.tz)

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -9,16 +9,13 @@ def _quadratic(xs, ys):
     return np.poly1d(coefficients)
 
 
-def quadratic_idxmax(x, y, model_range=None):
+def quadratic_vertex(x, y):
     """Fit a quadratic to the x, y data and return the x-value of the vertex.
 
     Parameters
     ----------
     x : array_like
     y : Series
-    model_range : array_like, optional
-        Range of x-values to find the max over. If not specified then
-        `x` is used.
 
     Returns
     -------
@@ -26,23 +23,9 @@ def quadratic_idxmax(x, y, model_range=None):
         x-value of the vertex of a quadratic fit to the data in `x`
         and `y`.
 
-    Examples
-    --------
-    >>> quadratic_idxmax(x=[-2, -1, 2, 4], y=[-4, -1, -4, -16])
-    -1
-
-    >>> quadratic_idxmax(
-    ...     x=[-2, -1, 2, 4],
-    ...     y=[-4, -1, -4, -16],
-    ...     model_range=[-4, -3, -2, -1, 0, 1, 2, 3, 4]
-    ... )
-    0
-
     """
-    model_range = model_range or x
     q = _quadratic(x, y)
-    model = q(model_range)
-    return model_range[np.argmax(model)]
+    return -q.c[1] / (2 * q.c[0])
 
 
 def quadratic_r2(x, y):


### PR DESCRIPTION
From scratch re-implementation of the algorithm form PVFleets QA. There are two substantial differences:
* Caller must pass a list of candidate azimuths and tilts. The PVFleets version includes an extra step where the candidate azimuths are chosen based on the data and uses a fixed set of tilts.
* The index of the solar position Series must cover the same time period as the data. In the PVFleets implementation only one year of solar position data is used. This adds some complexity that I think can be avoided by just requiring users pass in solar position for the same time period as the data. Users can pass arbitrary frequency solar position data and solar azimuth will be resampled and interpolated at 1-minute intervals before it is used. For the best results users should pass 1-minute solar position data.

closes #53 