### PR TITLE
Identify when the sun is up based on power or irradiance

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+     pvanalytics/tests/conftest.py

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest pvanalytics --runslow
 
   lint:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - pytest --cov=pvanalytics --cov-report term-missing
+  - pytest --cov=pvanalytics --cov-config=.coveragerc --cov-report term-missing pvanalytics --runslow
 
 after_success:
   - coveralls

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -210,3 +210,13 @@ identification.
 
    features.orientation.fixed_nrel
    features.orientation.tracking_nrel
+
+Daytime
+-------
+
+Functions that return a Boolean mask indicating day and night.
+
+.. autosummary::
+   :toctree: generated/
+
+   features.daytime.diff

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -1,0 +1,5 @@
+"""Functions for identifying daytime"""
+
+
+def diff(data):
+    return data > 0

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -109,7 +109,8 @@ def _filter_edge_of_day_errors(night, minutes_per_value):
 def _filter_and_normalize(series, outliers):
     # filter a series by removing outliers and clamping the minimum to
     # 0. Then normalize the series by the maximum deviation.
-    series = series[~outliers]
+    if outliers is not None:
+        series.loc[outliers] = np.nan
     series.loc[series < 0] = 0
     return (series - series.min()) / (series.max() - series.min())
 
@@ -154,10 +155,7 @@ def diff(series, outliers=None, low_value_threshold=0.003,
     Derived from the PVFleets QA Analysis project.
     """
     series = series.fillna(value=0)
-    series_norm = _filter_and_normalize(
-        series,
-        outliers or pd.Series(False, index=series.index)
-    )
+    series_norm = _filter_and_normalize(series, outliers).fillna(value=0)
     minutes_per_value = _freqstr_to_minutes(
         freq or pd.infer_freq(series.index)
     )

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -63,7 +63,7 @@ def _correct_midday_errors(night, minutes_per_value, hours_min,
 
 
 def _correct_edge_of_day_errors(night, minutes_per_value,
-                                daytime_difference_max,
+                                day_length_difference_max,
                                 day_length_window, correction_window):
     # Identify day-time periods that are "too short" and replace
     # values with the majority truth-value for the same time in the
@@ -86,7 +86,7 @@ def _correct_edge_of_day_errors(night, minutes_per_value,
         window=str(day_length_window) + 'D'
     ).median()
     # flag days that are more than 30 minutes shorter than the median
-    short_days = day_length < (day_length_median - daytime_difference_max)
+    short_days = day_length < (day_length_median - day_length_difference_max)
     invalid = short_days.groupby(short_days.index.date).transform(
         lambda day: any(day)
     )
@@ -114,7 +114,7 @@ def power_or_irradiance(series, outliers=None,
                         low_diff_threshold=0.0005, median_days=7,
                         clipping=None, freq=None,
                         correction_window=31, hours_min=5,
-                        daytime_difference_max=30,
+                        day_length_difference_max=30,
                         day_length_window=14):
     """Return True for values that are during the day.
 
@@ -168,8 +168,8 @@ def power_or_irradiance(series, outliers=None,
         Minimum number of hours in a contiguous period of day or
         night. A day/night period shorter than `hours_min` is
         flagged for error correction.
-    daytime_difference_max : float, default 30
-        Days with length that is `daytime_difference_max` minutes less
+    day_length_difference_max : float, default 30
+        Days with length that is `day_length_difference_max` minutes less
         than the median length of surrounding days are flagged for
         corrections.
     day_length_window : int, default 14
@@ -225,7 +225,7 @@ def power_or_irradiance(series, outliers=None,
     night_corrected_edges = _correct_edge_of_day_errors(
         night_corrected_clipping,
         minutes_per_value,
-        daytime_difference_max,
+        day_length_difference_max,
         day_length_window,
         correction_window
     )

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -11,6 +11,7 @@ def _rolling_by_minute(data, days, f, sort=True):
         data.index.hour * 60 + data.index.minute
     ).rolling(
         min_periods=1,
+        center=True,
         window=days
     )
     result = f(rolling).reset_index(0, drop=True)

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -122,7 +122,7 @@ def _freqstr_to_minutes(freqstr):
 
 def diff(series, outliers=None, low_value_threshold=0.003,
          low_median_threshold=0.0015, low_diff_threshold=0.0005,
-         clipping=None):
+         clipping=None, freq=None):
     """Return True for values that are during the day.
 
     Parameters
@@ -146,12 +146,21 @@ def diff(series, outliers=None, low_value_threshold=0.003,
         Boolean time series with True for times that are during the
         day.
 
+    Notes
+    -----
+
+    ``NA`` values are treated like zeros.
+
+    Derived from the PVFleets QA Analysis project.
     """
+    series = series.fillna(value=0)
     series_norm = _filter_and_normalize(
         series,
         outliers or pd.Series(False, index=series.index)
     )
-    minutes_per_value = _freqstr_to_minutes(pd.infer_freq(series.index))
+    minutes_per_value = _freqstr_to_minutes(
+        freq or pd.infer_freq(series.index)
+    )
     first_order_diff = series_norm.diff() / minutes_per_value
     rolling_median = _rolling_by_minute(
         series_norm,

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -162,11 +162,14 @@ def power_or_irradiance(series, outliers=None,
         Boolean time series with True for values in `series` that are
         outliers.
     low_value_threshold : float, default 0.003
-        Maximum normalized power or irradiance value for a time to be considered night.
+        Maximum normalized power or irradiance value for a time to be
+        considered night.
     low_median_threshold : float, default 0.0015
-        Maximum rolling median of power or irradiance for a time to be considered night.
+        Maximum rolling median of power or irradiance for a time to be
+        considered night.
     low_diff_threshold : float, default 0.0005
-        Maximum derivative of normalized power or irradiance for a time to be considered night.
+        Maximum derivative of normalized power or irradiance for a time
+        to be considered night.
     median_days : int, default 7
         Number of days to use to calculate the rolling median at each
         minute.
@@ -181,8 +184,9 @@ def power_or_irradiance(series, outliers=None,
         night. A day/night period shorter than `hours_min` is
         flagged for error correction.
     daytime_difference_max : float, default 30
-        Days with length that is `daytime_difference_max` minutes less than the median
-        length of surrounding days are flagged for corrections.
+        Days with length that is `daytime_difference_max` minutes less
+        than the median length of surrounding days are flagged for
+        corrections.
     day_length_window : int, default 14
         The length of the rolling window used for calculating the
         median length of the day when correcting errors in the morning

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -119,9 +119,11 @@ def _freqstr_to_minutes(freqstr):
     ).seconds / 60
 
 
-def diff(series, outliers=None, low_value_threshold=0.003,
-         low_median_threshold=0.0015, low_diff_threshold=0.0005,
-         clipping=None, freq=None):
+def power_or_irradiance(series, outliers=None,
+                        low_value_threshold=0.003,
+                        low_median_threshold=0.0015,
+                        low_diff_threshold=0.0005, clipping=None,
+                        freq=None):
     """Return True for values that are during the day.
 
     After removing outliers and normalizing the data, periods of

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -72,14 +72,14 @@ def _smooth_if_invalid(series, invalid):
     return (~invalid & series) | (invalid & _from_numeric(smoothed))
 
 
-def _filter_midday_errors(night, minutes_per_value):
+def _correct_midday_errors(night, minutes_per_value):
     # identify periods of time that appear to switch from night to day
     # (or day to night) on too short a time scale to be reasonable.
     invalid = _run_lengths(night)*minutes_per_value <= 5*60  # 5 hours
     return _smooth_if_invalid(night, invalid)
 
 
-def _filter_edge_of_day_errors(night, minutes_per_value):
+def _correct_edge_of_day_errors(night, minutes_per_value):
     # identify night-time periods that are "too long" and replace
     # values with the 31-day rolling median value for that minute.
     #
@@ -203,10 +203,10 @@ def power_or_irradiance(series, outliers=None,
     # Fix erroneous classifications (e.g. midday outages where power
     # goes to 0 and stays there for several hours, clipping classified
     # as night, and night-time periods that are too long)
-    night_corrected_midday = _filter_midday_errors(night, minutes_per_value)
+    night_corrected_midday = _correct_midday_errors(night, minutes_per_value)
     night_corrected_clipping = ~((clipping or False)
                                  | (~night_corrected_midday))
-    night_corrected_edges = _filter_edge_of_day_errors(
+    night_corrected_edges = _correct_edge_of_day_errors(
         night_corrected_clipping, minutes_per_value
     )
     return ~night_corrected_edges

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -154,7 +154,7 @@ def diff(series, outliers=None, low_value_threshold=0.003,
     low_value_threshold : float, default 0.003
         Maximum normalized value for a time to be considered night.
     low_median_threshold : float, default 0.0015
-        Minimum rolling median for a time to be considered night.
+        Maximum rolling median for a time to be considered night.
     low_diff_threshold : float, default 0.0005
         Maximum derivative for a time to be considered night.
     clipping : Series, optional

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -1,5 +1,143 @@
 """Functions for identifying daytime"""
+import numpy as np
+import pandas as pd
 
 
-def diff(data):
-    return data > 0
+def _rolling_by_minute(data, days, f, sort=True):
+    # apply `f` to a rolling window of length `days` at each minute of
+    # the day.
+    rolling = data.groupby(
+        data.index.hour * 60 + data.index.minute
+    ).rolling(
+        min_periods=1,
+        center=True,
+        window=days
+    )
+    result = f(rolling).reset_index(0, drop=True)
+    if sort:
+        return result.sort_index()
+    return result
+
+
+def _run_lengths(series):
+    # Count the number of equal values adjacent to each value.
+    #
+    # Examples
+    # --------
+    # >>> _run_lengths(pd.Series([True, True, True]))
+    # 0    3
+    # 1    3
+    # 2    3
+    #
+    # >>> _run_lengths(
+    # ...     pd.Series([True, False, False, True, True, False]
+    # ... ))
+    # 0    1
+    # 1    2
+    # 2    2
+    # 3    2
+    # 4    2
+    # 5    1
+    runs = (series != series.shift(1)).cumsum()
+    return runs.groupby(runs).transform('count')
+
+
+def _to_numeric(series):
+    # Convert a Boolean series to a numeric series
+    #
+    # False -> 1, True -> 2, NA -> 3
+    numeric_series = pd.Series(index=series.index, dtype='float64')
+    numeric_series.loc[~series] = 1
+    numeric_series.loc[series] = 2
+    numeric_series.loc[series.isna()] = 3
+    return numeric_series
+
+
+def _from_numeric(series):
+    # Inverse of :py:func:`_to_numeric()`
+    boolean_series = series == 2
+    boolean_series.loc[series == 3] = np.nan
+    return boolean_series
+
+
+def _filter_midday_errors(night):
+    # identify periods of time that appear to switch from night to day
+    # (or day to night) on too short a time scale to be reasonable.
+    # TODO make this adapable to the frequency of the series
+    invalid = _run_lengths(night) <= 20
+    # Need a numeric series so we can use Series.median()
+    numeric_series = _to_numeric(night)
+    smoothed = round(
+        _rolling_by_minute(
+            numeric_series,
+            days=31,
+            f=pd.core.window.RollingGroupby.median
+        )
+    )
+    return night | (invalid & _from_numeric(smoothed))
+
+
+def _filter_and_normalize(series, outliers):
+    # filter a series by removing outliers and clamping the minimum to
+    # 0. Then normalize the series by the maximum deviation.
+    series = series[~outliers]
+    series.loc[series < 0] = 0
+    return (series - series.min()) / (series.max() - series.min())
+
+
+def diff(series, outliers=None, low_value_threshold=0.003,
+         low_median_threshold=0.0015, low_diff_threshold=0.0015,
+         clipping=None):
+    """Return True for values that are during the day.
+
+    Parameters
+    ----------
+    series : Series
+        Time series of power or irradiance.
+    outliers : Series, optional
+        Boolean time series with True for values in `series` that are
+        outliers.
+    low_value_threshold : float, default 0.003
+        Maximum normalized value for a time to be considered night.
+    low_median_threshold : float, default 0.0015
+        Minimum rolling median for a time to be considered night.
+    clipping : Series, optional
+        True when clipping indicated. Any values where clipping is
+        indicated are automatically considered 'daytime'.
+
+    Returns
+    -------
+    Series
+        Boolean time series with True for times that are during the
+        day.
+
+    """
+    series_norm = _filter_and_normalize(
+        series,
+        outliers or pd.Series(False, index=series.index)
+    )
+    first_order_diff = series_norm.diff()
+    rolling_median = _rolling_by_minute(
+        series_norm,
+        days=7,
+        f=pd.core.window.RollingGroupby.median
+    )
+
+    # Night-time if two of the following are satisfied:
+    # - Near-zero value
+    # - Near-zero first-order derivative
+    # - Near-zero rolling median
+    low_value = series_norm <= low_value_threshold
+    low_median = rolling_median <= low_median_threshold
+    low_diff = abs(first_order_diff) <= low_diff_threshold
+
+    night = ((low_value & low_diff)
+             | (low_value & low_median)
+             | (low_diff & low_median))
+    # Fix erroneous classifications (e.g. midday outages where power
+    # goes to 0 and stays there for several hours)
+    night = _filter_midday_errors(night)
+    # TODO optional validation against clearsky daylight hours
+    # If a clipping mask was provided mark all clipped values as
+    # daytime
+    return (clipping or False) | (~night)

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -11,7 +11,6 @@ def _rolling_by_minute(data, days, f, sort=True):
         data.index.hour * 60 + data.index.minute
     ).rolling(
         min_periods=1,
-        center=True,
         window=days
     )
     result = f(rolling).reset_index(0, drop=True)

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -83,7 +83,7 @@ def _correct_midday_errors(night, minutes_per_value, hours_min,
 def _correct_edge_of_day_errors(night, minutes_per_value,
                                 daytime_difference_max,
                                 day_length_window, correction_window):
-    # identify night-time periods that are "too long" and replace
+    # identify day-time periods that are "too short" and replace
     # values with the `correction_window`-day rolling median value for
     # that minute.
     #
@@ -136,8 +136,7 @@ def power_or_irradiance(series, outliers=None,
                         day_length_window=14):
     """Return True for values that are during the day.
 
-    After removing outliers and normalizing the data, periods of
-    low-slope and low-value are identified as night. A time is
+    After removing outliers and normalizing the data, a time is
     classified as night when two of the following three criteria are
     satisfied:
 
@@ -146,13 +145,12 @@ def power_or_irradiance(series, outliers=None,
     - near-zero rolling median at the same time over the surrounding
       week (see `median_days`)
 
-    It is possible that mid-day times where power goes near zero or
-    stops changing can be incorrectly classified as night. To correct
-    these errors times where the total duration of periods marked
-    night or day is too long or too short are identified and values at
-    these times are compared to values at the same time for the
-    preceding two weeks and following two weeks. The day/night value
-    is adjusted to match the median value of these days.
+    Mid-day times where power goes near zero or
+    stops changing may be incorrectly classified as night. To correct
+    these errors, night or day periods with duration that is too long or
+    too short are identified, and times in these periods are re-classified
+    to have the majority value at the same time on preceding and
+    following days (as set by `correction_window`).
 
     Finally any values that are True in `clipping` are marked as day.
 
@@ -164,11 +162,11 @@ def power_or_irradiance(series, outliers=None,
         Boolean time series with True for values in `series` that are
         outliers.
     low_value_threshold : float, default 0.003
-        Maximum normalized value for a time to be considered night.
+        Maximum normalized power or irradiance value for a time to be considered night.
     low_median_threshold : float, default 0.0015
-        Maximum rolling median for a time to be considered night.
+        Maximum rolling median of power or irradiance for a time to be considered night.
     low_diff_threshold : float, default 0.0005
-        Maximum derivative for a time to be considered night.
+        Maximum derivative of normalized power or irradiance for a time to be considered night.
     median_days : int, default 7
         Number of days to use to calculate the rolling median at each
         minute.
@@ -180,13 +178,11 @@ def power_or_irradiance(series, outliers=None,
         day/night classification errors.
     hours_min : float, default 5
         Minimum number of hours in a contiguous period of day or
-        night. If a day/night period is shorter than this then it is
+        night. A day/night period shorter than `hours_min` is
         flagged for error correction.
     daytime_difference_max : float, default 30
-        When looking for day that end too early or start too late any
-        day where the hours of daylight is more then
-        `daytime_difference_max` minutes shorter than the median
-        length of surrounding days.
+        Days with length that is `daytime_difference_max` minutes less than the median
+        length of surrounding days are flagged for corrections.
     day_length_window : int, default 14
         The length of the rolling window used for calculating the
         median length of the day when correcting errors in the morning

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -57,7 +57,7 @@ def _from_numeric(series):
     # Inverse of :py:func:`_to_numeric()`
     boolean_series = series == 2
     boolean_series.loc[series == 3] = np.nan
-    return boolean_series
+    return boolean_series.astype('bool')
 
 
 def _filter_midday_errors(night):
@@ -74,7 +74,7 @@ def _filter_midday_errors(night):
             f=pd.core.window.RollingGroupby.median
         )
     )
-    return night | (invalid & _from_numeric(smoothed))
+    return (~invalid & night) | (invalid & _from_numeric(smoothed))
 
 
 def _filter_and_normalize(series, outliers):

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -158,6 +158,9 @@ def power_or_irradiance(series, outliers=None,
     clipping : Series, optional
         True when clipping indicated. Any values where clipping is
         indicated are automatically considered 'daytime'.
+    freq : str, optional
+        A pandas freqstr specifying the expected timestamp spacing for
+        the series. If None, the frequency will be inferred from the index.
     correction_window : int, default 31
         Number of adjacent days to examine when correcting
         day/night classification errors.

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -126,6 +126,26 @@ def diff(series, outliers=None, low_value_threshold=0.003,
          clipping=None, freq=None):
     """Return True for values that are during the day.
 
+    After removing outliers and normalizing the data, periods of
+    low-slope and low-value are identified as night. A time is
+    classified as night when two of the following three criteria are
+    satisfied:
+
+    - near-zero value
+    - near-zero first-order derivative
+    - near-zero rolling median at the same time over the surrounding
+      week
+
+    It is possible that mid-day times where power goes near zero or
+    stops changing can be incorrectly classified as night. To correct
+    these errors times where the total duration of periods marked
+    night or day is too long or too short are identified and values at
+    these times are compared to values at the same time for the
+    preceding two weeks and following two weeks. The day/night value
+    is adjusted to match the median value of these days.
+
+    Finally any values that are True in `clipping` are marked as day.
+
     Parameters
     ----------
     series : Series
@@ -137,6 +157,8 @@ def diff(series, outliers=None, low_value_threshold=0.003,
         Maximum normalized value for a time to be considered night.
     low_median_threshold : float, default 0.0015
         Minimum rolling median for a time to be considered night.
+    low_diff_threshold : float, default 0.0005
+        Maximum derivative for a time to be considered night.
     clipping : Series, optional
         True when clipping indicated. Any values where clipping is
         indicated are automatically considered 'daytime'.
@@ -153,6 +175,7 @@ def diff(series, outliers=None, low_value_threshold=0.003,
     ``NA`` values are treated like zeros.
 
     Derived from the PVFleets QA Analysis project.
+
     """
     series = series.fillna(value=0)
     series_norm = _filter_and_normalize(series, outliers).fillna(value=0)

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pandas.tseries import frequencies
 
 
-def _rolling_by_minute(data, days, f, sort=True):
+def _rolling_by_minute(data, days, f):
     # apply `f` to a rolling window of length `days` at each minute of
     # the day.
     rolling = data.groupby(
@@ -15,9 +15,7 @@ def _rolling_by_minute(data, days, f, sort=True):
         window=days
     )
     result = f(rolling).reset_index(0, drop=True)
-    if sort:
-        return result.sort_index()
-    return result
+    return result.sort_index()
 
 
 def _run_lengths(series):

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -129,9 +129,11 @@ def _freqstr_to_minutes(freqstr):
 def power_or_irradiance(series, outliers=None,
                         low_value_threshold=0.003,
                         low_median_threshold=0.0015,
-                        low_diff_threshold=0.0005, clipping=None,
-                        freq=None, correction_window=31, hours_min=5,
-                        daytime_difference_max=30, day_length_window=14):
+                        low_diff_threshold=0.0005, median_days=7,
+                        clipping=None, freq=None,
+                        correction_window=31, hours_min=5,
+                        daytime_difference_max=30,
+                        day_length_window=14):
     """Return True for values that are during the day.
 
     After removing outliers and normalizing the data, periods of
@@ -142,7 +144,7 @@ def power_or_irradiance(series, outliers=None,
     - near-zero value
     - near-zero first-order derivative
     - near-zero rolling median at the same time over the surrounding
-      week
+      week (see `median_days`)
 
     It is possible that mid-day times where power goes near zero or
     stops changing can be incorrectly classified as night. To correct
@@ -167,6 +169,9 @@ def power_or_irradiance(series, outliers=None,
         Maximum rolling median for a time to be considered night.
     low_diff_threshold : float, default 0.0005
         Maximum derivative for a time to be considered night.
+    median_days : int, default 7
+        Number of days to use to calculate the rolling median at each
+        minute.
     clipping : Series, optional
         True when clipping indicated. Any values where clipping is
         indicated are automatically considered 'daytime'.
@@ -209,7 +214,7 @@ def power_or_irradiance(series, outliers=None,
     first_order_diff = series_norm.diff() / minutes_per_value
     rolling_median = _rolling_by_minute(
         series_norm,
-        days=7,
+        days=median_days,
         f=pd.core.window.RollingGroupby.median
     )
 

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -154,7 +154,7 @@ def power_or_irradiance(series, outliers=None,
         to be considered night.
     median_days : int, default 7
         Number of days to use to calculate the rolling median at each
-        minute.
+        minute. [days]
     clipping : Series, optional
         True when clipping indicated. Any values where clipping is
         indicated are automatically considered 'daytime'.
@@ -163,11 +163,11 @@ def power_or_irradiance(series, outliers=None,
         the series. If None, the frequency will be inferred from the index.
     correction_window : int, default 31
         Number of adjacent days to examine when correcting
-        day/night classification errors.
+        day/night classification errors. [days]
     hours_min : float, default 5
         Minimum number of hours in a contiguous period of day or
         night. A day/night period shorter than `hours_min` is
-        flagged for error correction.
+        flagged for error correction. [hours]
     day_length_difference_max : float, default 30
         Days with length that is `day_length_difference_max` minutes less
         than the median length of surrounding days are flagged for
@@ -175,7 +175,7 @@ def power_or_irradiance(series, outliers=None,
     day_length_window : int, default 14
         The length of the rolling window used for calculating the
         median length of the day when correcting errors in the morning
-        or afternoon.
+        or afternoon. [days]
 
     Returns
     -------

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -94,7 +94,7 @@ def _filter_edge_of_day_errors(night, minutes_per_value):
     day_length = night.groupby(night.cumsum()).transform(
         lambda x: len(x) * minutes_per_value
     )
-    # remove night time values so they don't interfer with the mediand
+    # remove night time values so they don't interfere with the median
     # day length.
     day_length.loc[night] = np.nan
     day_length_median = day_length.rolling(window='14D').median()

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 import pandas as pd
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 import pandas as pd
+from pvlib import location
 
 
 def pytest_addoption(parser):
@@ -22,6 +23,18 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+@pytest.fixture(scope='module')
+def albuquerque():
+    """pvlib Location for Albuquerque, NM."""
+    return location.Location(
+        35.0844,
+        -106.6504,
+        name='Albuquerque',
+        altitude=1500,
+        tx='Etc/GMT+7'
+    )
 
 
 @pytest.fixture

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -3,6 +3,25 @@ import pytest
 import numpy as np
 import pandas as pd
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
 
 @pytest.fixture
 def quadratic():

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -115,3 +115,39 @@ def test_daytime_split_day():
         clearsky['ghi'],
         daytime.diff(clearsky['ghi'])
     )
+
+
+def test_daytime_hour_spacing(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/20/2020', freq='H'),
+        model='simplified_solis'
+    )
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(clearsky['ghi'])
+    )
+    # punch a mid-day hole
+    ghi = clearsky['ghi'].copy()
+    ghi.loc['1/10/2020 12:00':'1/10/2020 14:00'] = 0
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(ghi)
+    )
+
+
+def test_daytime_minute_spacing(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/20/2020', freq='T'),
+        model='simplified_solis'
+    )
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(clearsky['ghi'])
+    )
+    # punch a mid-day hole
+    ghi = clearsky['ghi'].copy()
+    ghi.loc['1/10/2020 12:00':'1/10/2020 14:00'] = 0
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(ghi)
+    )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -43,7 +43,7 @@ def clearsky_january(request, albuquerque):
 #
 # - [ ] Can detect daytime in a period where there are variable days.
 #
-# - [ ] Data with many missing values is handled gracefully
+# - [x] Data with many missing values is handled gracefully
 #
 # - [x] Data with different timestamp spacing
 
@@ -173,12 +173,12 @@ def test_daytime_missing_data(clearsky_january):
     ghi.loc['1/5/2020 16:00':'1/6/2020 11:30'] = np.nan
     # test with NaNs
     _assert_daytime_no_shoulder(
-        ghi,
+        clearsky_january['ghi'],
         daytime.diff(ghi)
     )
     # test with completely missing data
     ghi.dropna(inplace=True)
     _assert_daytime_no_shoulder(
         ghi,
-        daytime.diff(ghi)
+        daytime.diff(ghi, freq=pd.infer_freq(clearsky_january.index))
     )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -6,11 +6,6 @@ from pvlib.location import Location
 from pvanalytics.features import daytime
 
 
-@pytest.fixture(scope='module')
-def albuquerque():
-    return Location(35, -106, altitude=1500)
-
-
 @pytest.fixture(scope='module',
                 params=['H', '15T', pytest.param('T', marks=pytest.mark.slow)])
 def clearsky_january(request, albuquerque):

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -31,12 +31,12 @@ def albuquerque():
 #
 # - [ ] Data with many missing values is handled gracefully
 #
-# - [ ] Data with different timestamp spacing
+# - [x] Data with different timestamp spacing
 
 
 def _assert_daytime_no_shoulder(clearsky, output):
     day = clearsky > 0
-    shoulder = day & (clearsky <= 2)
+    shoulder = day & (clearsky <= 3)
     assert_series_equal(
         output | shoulder,
         day,
@@ -150,4 +150,34 @@ def test_daytime_minute_spacing(albuquerque):
     _assert_daytime_no_shoulder(
         clearsky['ghi'],
         daytime.diff(ghi)
+    )
+
+def test_daytime_daylight_savings(albuquerque):
+    spring = pd.date_range(
+        start='2/10/2020',
+        end='4/10/2020',
+        freq='15T',
+        tz='America/Denver'
+    )
+    clearsky_spring = albuquerque.get_clearsky(
+        spring,
+        model='simplified_solis'
+    )
+    _assert_daytime_no_shoulder(
+        clearsky_spring['ghi'],
+        daytime.diff(clearsky_spring['ghi'])
+    )
+    fall = pd.date_range(
+        start='10/1/2020',
+        end='12/1/2020',
+        freq='15T',
+        tz='America/Denver'
+    )
+    clearsky_fall = albuquerque.get_clearsky(
+        fall,
+        model='simplified_solis'
+    )
+    _assert_daytime_no_shoulder(
+        clearsky_fall['ghi'],
+        daytime.diff(clearsky_fall['ghi'])
     )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -168,6 +168,21 @@ def test_daytime_zero_at_start_of_day(clearsky_january):
     )
 
 
+def test_daytime_outliers(clearsky_january):
+    outliers = pd.Series(False, index=clearsky_january.index)
+    outliers.loc['1/5/2020 13:00'] = True
+    outliers.loc['1/5/2020 14:00'] = True
+    outliers.loc['1/10/2020 02:00'] = True
+    ghi = clearsky_january['ghi'].copy()
+    ghi.loc['1/5/2020 1300'] = 999
+    ghi.loc['1/5/2020 14:00'] = -999
+    ghi.loc['1/10/2020 02:00'] = -999
+    _assert_daytime_no_shoulder(
+        clearsky_january['ghi'],
+        daytime.diff(clearsky_january['ghi'], outliers=outliers)
+    )
+
+
 def test_daytime_missing_data(clearsky_january):
     ghi = clearsky_january['ghi'].copy()
     ghi.loc['1/5/2020 16:00':'1/6/2020 11:30'] = np.nan

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -12,7 +12,8 @@ def albuquerque():
     return Location(35, -106, altitude=1500)
 
 
-@pytest.fixture(scope='module', params=['H', '15T', 'T'])
+@pytest.fixture(scope='module',
+                params=['H', '15T', pytest.param('T', marks=pytest.mark.slow)])
 def clearsky_january(request, albuquerque):
     return albuquerque.get_clearsky(
         pd.date_range(

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -47,25 +47,12 @@ def test_daytime_diff(albuquerque):
 
 def test_midday_zero(albuquerque):
     clearsky = albuquerque.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/2/2020', freq='15T', tz='MST'),
+        pd.date_range(start='1/1/2020', end='1/20/2020', freq='15T', tz='MST'),
         model='simplified_solis'
     )
     ghi = clearsky['ghi']
     day = ghi > 2
-    ghi.loc['1/1/2020 13:00':'1/1/2020 14:00'] = 0
-    assert_series_equal(
-        ghi[daytime.diff(ghi)],
-        ghi[day],
-        check_names=False
-    )
-
-    clearsky = albuquerque.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T', tz='MST'),
-        model='simplified_solis'
-    )
-    ghi = clearsky['ghi']
-    day = ghi > 2
-    ghi.loc[ghi.between_time('12:00', '14:00').index] = 0
+    ghi.loc[ghi['1/3/2020'].between_time('12:00', '14:00').index] = 0
     assert_series_equal(
         daytime.diff(ghi),
         day,
@@ -88,7 +75,7 @@ def test_daytime_with_clipping(albuquerque):
     )
     # Include a period where data goes to zero during clipping and
     # returns to normal after the clipping is done
-    ghi.loc[ghi.between_time('12:30', '15:30').index] = 0
+    ghi.loc[ghi['1/3/2020'].between_time('12:30', '15:30').index] = 0
     assert_series_equal(
         daytime.diff(ghi),
         day,

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -153,6 +153,7 @@ def test_daytime_minute_spacing(albuquerque):
         daytime.diff(ghi)
     )
 
+
 def test_daytime_daylight_savings(albuquerque):
     spring = pd.date_range(
         start='2/10/2020',
@@ -190,7 +191,25 @@ def test_daytime_zero_at_end_of_day(albuquerque):
         model='simplified_solis'
     )
     ghi = clearsky['ghi'].copy()
+    ghi.loc['1/5/2020 16:00':'1/6/2020 00:00'] = 0
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(ghi)
+    )
     ghi.loc['1/5/2020 12:00':'1/6/2020 00:00'] = 0
+    _assert_daytime_no_shoulder(
+        clearsky['ghi'],
+        daytime.diff(ghi)
+    )
+
+
+def test_daytime_zero_at_start_of_day(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/20/2020', freq='15T', tz='MST'),
+        model='simplified_solis'
+    )
+    ghi = clearsky['ghi'].copy()
+    ghi.loc['1/5/2020 00:00':'1/5/2020 09:00'] = 0
     _assert_daytime_no_shoulder(
         clearsky['ghi'],
         daytime.diff(ghi)

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -43,14 +43,14 @@ def test_daytime_with_clipping(clearsky_january):
     ghi.loc[ghi >= 500] = 500
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
     # Include a period where data goes to zero during clipping and
     # returns to normal after the clipping is done
     ghi.loc[ghi['1/3/2020'].between_time('12:30', '15:30').index] = 0
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
 
 
@@ -60,7 +60,7 @@ def test_daytime_overcast(clearsky_january):
     ghi.loc['1/7/2020':'1/8/2020'] *= 0.6
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
 
 
@@ -72,21 +72,21 @@ def test_daytime_split_day():
     )
     _assert_daytime_no_shoulder(
         clearsky['ghi'],
-        daytime.diff(clearsky['ghi'])
+        daytime.power_or_irradiance(clearsky['ghi'])
     )
 
 
 def test_daytime(clearsky_january):
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(clearsky_january['ghi'])
+        daytime.power_or_irradiance(clearsky_january['ghi'])
     )
     # punch a mid-day hole
     ghi = clearsky_january['ghi'].copy()
     ghi.loc['1/10/2020 12:00':'1/10/2020 14:00'] = 0
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
 
 
@@ -103,7 +103,7 @@ def test_daytime_daylight_savings(albuquerque):
     )
     _assert_daytime_no_shoulder(
         clearsky_spring['ghi'],
-        daytime.diff(clearsky_spring['ghi'])
+        daytime.power_or_irradiance(clearsky_spring['ghi'])
     )
     fall = pd.date_range(
         start='10/1/2020',
@@ -117,7 +117,7 @@ def test_daytime_daylight_savings(albuquerque):
     )
     _assert_daytime_no_shoulder(
         clearsky_fall['ghi'],
-        daytime.diff(clearsky_fall['ghi'])
+        daytime.power_or_irradiance(clearsky_fall['ghi'])
     )
 
 
@@ -126,13 +126,13 @@ def test_daytime_zero_at_end_of_day(clearsky_january):
     ghi.loc['1/5/2020 16:00':'1/6/2020 00:00'] = 0
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
     # test a period of zeros starting earlier in the day
     ghi.loc['1/5/2020 12:00':'1/6/2020 00:00'] = 0
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
 
 
@@ -141,7 +141,7 @@ def test_daytime_zero_at_start_of_day(clearsky_january):
     ghi.loc['1/5/2020 00:00':'1/5/2020 09:00'] = 0
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
 
 
@@ -156,7 +156,7 @@ def test_daytime_outliers(clearsky_january):
     ghi.loc['1/10/2020 02:00'] = -999
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(clearsky_january['ghi'], outliers=outliers)
+        daytime.power_or_irradiance(clearsky_january['ghi'], outliers=outliers)
     )
 
 
@@ -166,13 +166,15 @@ def test_daytime_missing_data(clearsky_january):
     # test with NaNs
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )
     # test with completely missing data
     ghi.dropna(inplace=True)
     _assert_daytime_no_shoulder(
         ghi,
-        daytime.diff(ghi, freq=pd.infer_freq(clearsky_january.index))
+        daytime.power_or_irradiance(
+            ghi, freq=pd.infer_freq(clearsky_january.index)
+        )
     )
 
 
@@ -183,5 +185,5 @@ def test_daytime_variable(clearsky_january):
     ghi.loc['1/11/2020'] *= np.random.rand(len(ghi['1/11/2020']))
     _assert_daytime_no_shoulder(
         clearsky_january['ghi'],
-        daytime.diff(ghi)
+        daytime.power_or_irradiance(ghi)
     )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -1,0 +1,127 @@
+"""Tests for :py:mod:`features.daytime`"""
+import pytest
+import pandas as pd
+from pandas.testing import assert_series_equal
+from pvlib.location import Location
+from pvanalytics.features import daytime
+
+
+@pytest.fixture(scope='module')
+def albuquerque():
+    return Location(35, -106, altitude=1500)
+
+
+# Testing plan
+#
+# - [x] Can detect the daytime period in one day of data.
+#
+# - [x] Can detect the daytime period(s) in data where day spans two
+#   dates.
+#
+# - [x] Can detect the correct daytime period in data where there is
+#   1-2 hours of zeros mid-day
+#
+# - [x] Can detect daytime in a period where there are 'overcast' days
+#   (i.e. ghi is 1/2 the normal value for a day or two)
+#
+# - [x] Can detect the daytime period in data with clipping (without
+#   passing a "clipping mask")
+#
+# - [ ] Can detect daytime in a period where there are variable days.
+#
+# - [ ] Data with many missing values is handled gracefully
+
+def test_daytime_diff(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/2/2020', freq='10T', tz='MST'),
+        model='simplified_solis'
+    )
+    # TODO Do I expect daytime.diff() to catch the early morning and
+    # late afternoon times that are near zero?
+    assert_series_equal(
+        daytime.diff(clearsky['ghi']),
+        clearsky['ghi'] > 0,
+        check_names=False
+    )
+
+
+def test_midday_zero(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/2/2020', freq='30T', tz='MST'),
+        model='simplified_solis'
+    )
+    ghi = clearsky['ghi']
+    day = ghi > 0
+    ghi.loc['1/1/2020 13:00':'1/1/2020 14:00'] = 0
+    # TODO As with previous test, need to decide how accurate we really
+    # expect this funciton to be.
+    assert_series_equal(
+        daytime.diff(ghi),
+        day,
+        check_names=False
+    )
+
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T', tz='MST'),
+        model='simplified_solis'
+    )
+    ghi = clearsky['ghi']
+    day = ghi > 0
+    ghi.loc[ghi.between_time('12:00', '14:00').index] = 0
+    assert_series_equal(
+        daytime.diff(ghi),
+        day,
+        check_names=False
+    )
+
+
+def test_daytime_with_clipping(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/10/2020', freq='10T', tz='MST'),
+        model='simplified_solis'
+    )
+    ghi = clearsky['ghi']
+    day = ghi > 0
+    ghi.loc[ghi >= 500] = 500
+    assert_series_equal(
+        daytime.diff(ghi),
+        day,
+        check_names=False
+    )
+    # Include a period where data goes to zero during clipping and
+    # returns to normal after the clipping is done
+    ghi.loc[ghi.between_time('12:30', '15:30').index] = 0
+    assert_series_equal(
+        daytime.diff(ghi),
+        day,
+        check_names=False
+    )
+
+
+def test_daytime_overcast(albuquerque):
+    clearsky = albuquerque.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T', tz='MST'),
+        model='simplified_solis'
+    )
+    ghi = clearsky['ghi']
+    day = ghi > 0
+    ghi.loc['1/3/2020':'1/5/2020'] *= 0.5
+    ghi.loc['1/7/2020':'1/8/2020'] *= 0.6
+    assert_series_equal(
+        daytime.diff(ghi),
+        day,
+        check_names=False
+    )
+
+
+def test_daytime_split_day():
+    location = Location(35, -150)
+    clearsky = location.get_clearsky(
+        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T'),  # no tz
+        model='simplified_solis'
+    )
+    assert_series_equal(
+        daytime.diff(clearsky['ghi']),
+        clearsky['ghi'] > 0,
+        check_names=False
+    )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -30,34 +30,32 @@ def albuquerque():
 # - [ ] Can detect daytime in a period where there are variable days.
 #
 # - [ ] Data with many missing values is handled gracefully
+#
+# - [ ] Data with different timestamp spacing
 
 def test_daytime_diff(albuquerque):
     clearsky = albuquerque.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/2/2020', freq='10T', tz='MST'),
+        pd.date_range(start='1/1/2020', end='1/2/2020', freq='15T', tz='MST'),
         model='simplified_solis'
     )
-    # TODO Do I expect daytime.diff() to catch the early morning and
-    # late afternoon times that are near zero?
     assert_series_equal(
         daytime.diff(clearsky['ghi']),
-        clearsky['ghi'] > 0,
+        clearsky['ghi'] > 2,
         check_names=False
     )
 
 
 def test_midday_zero(albuquerque):
     clearsky = albuquerque.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/2/2020', freq='30T', tz='MST'),
+        pd.date_range(start='1/1/2020', end='1/2/2020', freq='15T', tz='MST'),
         model='simplified_solis'
     )
     ghi = clearsky['ghi']
-    day = ghi > 0
+    day = ghi > 2
     ghi.loc['1/1/2020 13:00':'1/1/2020 14:00'] = 0
-    # TODO As with previous test, need to decide how accurate we really
-    # expect this funciton to be.
     assert_series_equal(
-        daytime.diff(ghi),
-        day,
+        ghi[daytime.diff(ghi)],
+        ghi[day],
         check_names=False
     )
 
@@ -66,7 +64,7 @@ def test_midday_zero(albuquerque):
         model='simplified_solis'
     )
     ghi = clearsky['ghi']
-    day = ghi > 0
+    day = ghi > 2
     ghi.loc[ghi.between_time('12:00', '14:00').index] = 0
     assert_series_equal(
         daytime.diff(ghi),
@@ -77,11 +75,11 @@ def test_midday_zero(albuquerque):
 
 def test_daytime_with_clipping(albuquerque):
     clearsky = albuquerque.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/10/2020', freq='10T', tz='MST'),
+        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T', tz='MST'),
         model='simplified_solis'
     )
     ghi = clearsky['ghi']
-    day = ghi > 0
+    day = ghi > 2
     ghi.loc[ghi >= 500] = 500
     assert_series_equal(
         daytime.diff(ghi),
@@ -104,7 +102,7 @@ def test_daytime_overcast(albuquerque):
         model='simplified_solis'
     )
     ghi = clearsky['ghi']
-    day = ghi > 0
+    day = ghi > 2
     ghi.loc['1/3/2020':'1/5/2020'] *= 0.5
     ghi.loc['1/7/2020':'1/8/2020'] *= 0.6
     assert_series_equal(
@@ -122,6 +120,6 @@ def test_daytime_split_day():
     )
     assert_series_equal(
         daytime.diff(clearsky['ghi']),
-        clearsky['ghi'] > 0,
+        clearsky['ghi'] > 2,
         check_names=False
     )

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -25,29 +25,6 @@ def clearsky_january(request, albuquerque):
     )
 
 
-# Testing plan
-#
-# - [x] Can detect the daytime period in one day of data.
-#
-# - [x] Can detect the daytime period(s) in data where day spans two
-#   dates.
-#
-# - [x] Can detect the correct daytime period in data where there is
-#   1-2 hours of zeros mid-day
-#
-# - [x] Can detect daytime in a period where there are 'overcast' days
-#   (i.e. ghi is 1/2 the normal value for a day or two)
-#
-# - [x] Can detect the daytime period in data with clipping (without
-#   passing a "clipping mask")
-#
-# - [ ] Can detect daytime in a period where there are variable days.
-#
-# - [x] Data with many missing values is handled gracefully
-#
-# - [x] Data with different timestamp spacing
-
-
 def _assert_daytime_no_shoulder(clearsky, output):
     # every night-time value in `output` has low or 0 irradiance
     assert all(clearsky[~output] < 3)
@@ -196,4 +173,15 @@ def test_daytime_missing_data(clearsky_january):
     _assert_daytime_no_shoulder(
         ghi,
         daytime.diff(ghi, freq=pd.infer_freq(clearsky_january.index))
+    )
+
+
+def test_daytime_variable(clearsky_january):
+    ghi = clearsky_january['ghi'].copy()
+    np.random.seed(1337)
+    ghi.loc['1/10/2020'] *= np.random.rand(len(ghi['1/10/2020']))
+    ghi.loc['1/11/2020'] *= np.random.rand(len(ghi['1/11/2020']))
+    _assert_daytime_no_shoulder(
+        clearsky_january['ghi'],
+        daytime.diff(ghi)
     )

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -1,7 +1,7 @@
 import pytest
 from pandas.util.testing import assert_series_equal
 import pandas as pd
-from pvlib import location, pvsystem, tracking, modelchain, irradiance
+from pvlib import pvsystem, tracking, modelchain, irradiance
 from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
 from pvanalytics.features import orientation
 
@@ -15,18 +15,6 @@ def times():
         closed='left',
         freq='H',
         tz='Etc/GMT+7'
-    )
-
-
-@pytest.fixture(scope='module')
-def albuquerque():
-    """pvlib Location for Albuquerque, NM."""
-    return location.Location(
-        35.0844,
-        -106.6504,
-        name='Albuquerque',
-        altitude=1500,
-        tx='Etc/GMT+7'
     )
 
 

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -6,7 +6,6 @@ import numpy as np
 
 import pytest
 from pandas.util.testing import assert_series_equal
-from pvlib import location
 
 from pvanalytics.quality import irradiance
 
@@ -254,16 +253,6 @@ def test_clearsky_limits_csi_max(times):
     assert_series_equal(
         irradiance.clearsky_limits(measured, clearsky, csi_max=1.2),
         expected
-    )
-
-
-@pytest.fixture
-def albuquerque():
-    return location.Location(
-        35,
-        -106,
-        elevation=2000,
-        tz='MST'
     )
 
 

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -2,7 +2,6 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pvlib import location
 from pandas.util.testing import assert_series_equal
 from pvanalytics.quality import weather
 
@@ -90,11 +89,8 @@ def test_wind_limits(weather_data):
     )
 
 
-def test_module_temperature():
+def test_module_temperature(albuquerque):
     """Module temperature is correlated with GHI."""
-    albuquerque = location.Location(
-        35.0844, -106.6504, altitude=5312, tz='MST'
-    )
     times = pd.date_range(
         start='01/01/2020',
         end='03/01/2020',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.16.0
-pandas>=0.25.0
+pandas>=0.25.0,<1.1.0
 pvlib>=0.7.0
 scipy>=1.3.0


### PR DESCRIPTION
## Description

Flag daytime periods based on power or irradiance data. Requires no knowledge of location or timezone. Reimplimentation of algorithm from PVFleets with some modifications. In a nutshell it looks for times where the derivative (approximated as a first-order difference) is non-zero and the data is large. Can handle intermittent periods of low values/low slope during the day by looking for too-short daytime periods and comparing to the day/night mask value on preceding and following days. Can be combined with a clipping mask to ensure clipping is flagged as daytime.

## Checklist

- [x] Added new API functions to `docs/api.rst`
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] consolidate fixtures (there is a fair amount of duplication in the new tests that should be eliminated)
- [x] add test with outlier mask
- [x] test with some variable days
- [x] Pull request is nearly complete and ready for detailed review
- [x] Either limit pandas version to < 1.1  or wait for 1.1.1 to be released ([bug in 1.1.0](https://github.com/pandas-dev/pandas/issues/35552))
