### PR TITLE
orientation._freqstr_to_hours returns hours

### DIFF
--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -1,5 +1,6 @@
 """Functions for identifying system orientation."""
 import pandas as pd
+from pandas.tseries import frequencies
 from pvanalytics.util import _fit, _group
 
 
@@ -55,9 +56,7 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
 
 def _freqstr_to_hours(freq):
     # Convert pandas freqstr to hours (as a float)
-    if freq.isalpha():
-        freq = '1' + freq
-    return pd.to_timedelta(freq).seconds / 60
+    return pd.to_timedelta(frequencies.to_offset(freq)).seconds / 3600
 
 
 def _hours(data, freq):

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -121,3 +121,9 @@ def test_stuck_tracker_profile(solarposition, clearsky):
         poa['poa_global'],
         solarposition['zenith'] < 70
     ).all()
+
+
+def test_frequency_to_hours():
+    assert orientation._freqstr_to_hours('H') == 1.0
+    assert orientation._freqstr_to_hours('15T') == 0.25
+    assert orientation._freqstr_to_hours('2H') == 2.0


### PR DESCRIPTION
Was incorrectly returning minutes, now returns hours. 

Also revised implementation to use the `pandas.tseries` API instead of our own custom logic.

## Checklist

- [x] Closes #72 
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] Pull request is nearly complete and ready for detailed review
