### PR TITLE
Identify surface orientation from AC power and clearsky irradiance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -241,7 +241,7 @@ power or plane of array irradiance measurements.
    :toctree: generated/
 
    system.infer_orientation_daily_peak
-   system.orientation_fit_pvwatts
+   system.infer_orientation_fit_pvwatts
 
 Metrics
 =======

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -241,6 +241,7 @@ power or plane of array irradiance measurements.
    :toctree: generated/
 
    system.infer_orientation_daily_peak
+   system.orientation_fit_pvwatts
 
 Metrics
 =======

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -496,6 +496,8 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     - the DC capacity of the system
     - the DC input limit of the inverter.
 
+    All parameters passed as a Series must have the same index.
+
     Parameters
     ----------
     power_ac : Series
@@ -533,6 +535,16 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
         :math:`r^2` value for the fit at the returned orientation.
 
     """
+    power_ac = power_ac.dropna()
+    ghi = ghi.dropna()
+    dhi = dhi.dropna()
+    dni = dni.dropna()
+    solar_azimuth = solar_azimuth.dropna()
+    solar_zenith = solar_zenith.dropna()
+    if isinstance(temperature, pd.Series):
+        temperature = temperature.dropna()
+    if isinstance(wind_speed, pd.Series):
+        wind_speed = wind_speed.dropna()
     if temperature_model_parameters is None:
         temperature_model_parameters = \
             TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -412,41 +412,42 @@ def _power_residuals_from_clearsky(system_params,
                                    wind_speed,
                                    temperature_coefficient,
                                    temperature_model_parameters):
-    # Return the residuals between a system with parameters given in `params`
-    # and the data in `power_ac`.
-    #
-    # Parameters
-    # ----------
-    # system_params : array-like
-    #     array of four floats: tilt, azimuth, DC capacity, and inverter
-    #     DC input limit.
-    # ghi : Series
-    #     Clear sky GHI
-    # dhi : Series
-    #     Clear sky DHI
-    # dni : Series
-    #     Clear sky DNI
-    # solar_zenith : Series
-    #     Solar zenith at the same times as data in `power_ac`
-    # solar_azimuth : Series
-    #     Solar azimuth at the same times as data in `power_ac`
-    # power_ac : Series
-    #     Measured AC power under clear sky conditions.
-    # temperature : float or Series
-    #     Air temperature at which to model the hypothetical system. If a
-    #     float then a constant temperature is used. If a Series, must have
-    #     the same index as `power_ac`. [C]
-    # wind_speed : float or Series
-    #     Wind speed. If a float then a constant wind speed is used. If a
-    #     Series, must have the same index as `power_ac`. [m/s]
-    # temperature_model_parameters : dict
-    #     Parameters fot the cell temperature model.
-    #
-    # Returns
-    # -------
-    # Series
-    #     Difference between `power_ac` and the PVWatts output with the
-    #     given parameters.
+    """Return the residuals between a system with parameters given in `params`
+    and the data in `power_ac`.
+
+    Parameters
+    ----------
+    system_params : array-like
+        array of four floats: tilt, azimuth, DC capacity, and inverter
+        DC input limit.
+    ghi : Series
+        Clear sky GHI
+    dhi : Series
+        Clear sky DHI
+    dni : Series
+        Clear sky DNI
+    solar_zenith : Series
+        Solar zenith at the same times as data in `power_ac`
+    solar_azimuth : Series
+        Solar azimuth at the same times as data in `power_ac`
+    power_ac : Series
+        Measured AC power under clear sky conditions.
+    temperature : float or Series
+        Air temperature at which to model the hypothetical system. If a
+        float then a constant temperature is used. If a Series, must have
+        the same index as `power_ac`. [C]
+    wind_speed : float or Series
+        Wind speed. If a float then a constant wind speed is used. If a
+        Series, must have the same index as `power_ac`. [m/s]
+    temperature_model_parameters : dict
+        Parameters fot the cell temperature model.
+
+    Returns
+    -------
+    Series
+        Difference between `power_ac` and the PVWatts output with the
+        given parameters.
+    """
     tilt = system_params[0]
     azimuth = system_params[1]
     dc_capacity = system_params[2]

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -412,7 +412,7 @@ def _power_residuals_from_clearsky(system_params,
                                    wind_speed,
                                    temperature_coefficient,
                                    temperature_model_parameters):
-    """Return the residuals between a system with parameters given in `params`
+    """Return the residuals between a system with parameters given in `system_params`
     and the data in `power_ac`.
 
     Parameters
@@ -439,14 +439,22 @@ def _power_residuals_from_clearsky(system_params,
     wind_speed : float or Series
         Wind speed. If a float then a constant wind speed is used. If a
         Series, must have the same index as `power_ac`. [m/s]
+    temperature_coefficient : float
+        Temperature coefficient of DC power. [1/C]
     temperature_model_parameters : dict
-        Parameters fot the cell temperature model.
+        Parameters for the cell temperature model.
 
     Returns
     -------
     Series
         Difference between `power_ac` and the PVWatts output with the
         given parameters.
+    
+    Notes
+    ------
+    Uses the defaults in `pvlib.irradiance.get_total_irradiance` to calculated plane-of-array
+    irradiance, i.e., the isotropic model for sky diffuse irradiance, and the Perez irradiance
+    transposition model.
     """
     tilt = system_params[0]
     azimuth = system_params[1]
@@ -485,9 +493,12 @@ def infer_orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
                                   temperature=25, wind_speed=0,
                                   temperature_coefficient=-0.004,
                                   temperature_model_parameters=None):
-    """Get the tilt and azimuth that give pvwatts output that most closely
+    """Get the tilt and azimuth that give PVWatts output that most closely
     fits the data in `power_ac`.
 
+    Input data `power_ac`, `ghi`, `dhi`, `dni` should reflect clear-sky
+    conditions.
+    
     Uses non-linear least squares to optimize over four free variables
     to find the values that result in the best fit between power modeled
     using PVWatts and `power_ac`. The four free variables are
@@ -506,11 +517,11 @@ def infer_orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     power_ac : Series
         AC power from the system in clear sky conditions.
     ghi : Series
-        Clear sky GHI with same index as `power_ac`.
+        Clear sky GHI with same index as `power_ac`. [W/m^2]
     dhi : Series
-        Clear sky DHI with same index as `power_ac`.
+        Clear sky DHI with same index as `power_ac`. [W/m^2]
     dni : Series
-        Clear sky DNI with same index as `power_ac`.
+        Clear sky DNI with same index as `power_ac`. [W/m^2]
     solar_zenith : Series
         Solar zenith. [degrees]
     solar_azimuth : Series

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -480,11 +480,11 @@ def _rsquared(data, residuals):
     return r*r
 
 
-def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
-                            solar_zenith, solar_azimuth,
-                            temperature=25, wind_speed=0,
-                            temperature_coefficient=-0.004,
-                            temperature_model_parameters=None):
+def infer_orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
+                                  solar_zenith, solar_azimuth,
+                                  temperature=25, wind_speed=0,
+                                  temperature_coefficient=-0.004,
+                                  temperature_model_parameters=None):
     """Get the tilt and azimuth that give pvwatts output that most closely
     fits the data in `power_ac`.
 

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -508,6 +508,12 @@ def infer_orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     - the DC capacity of the system
     - the DC input limit of the inverter.
 
+    Of these four parameters, only tilt and azimuth are returned. While, DC
+    capacity and the DC input limit are calculated, their values may not be
+    accurate. While its value is not returned, because the DC input limit is
+    used as a free variable for the optimization process, this function
+    can operate on `power_ac` data that includes inverter clipping.
+
     All parameters passed as a Series must have the same index and must not
     contain any undefined values (i.e. NaNs). If any input contains NaNs a
     ValueError is raised.

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -490,6 +490,7 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     Uses non-linear least squares to optimize over four free variables
     to find the values that result in the best fit between power modeled
     using PVWatts and `power_ac`. The four free variables are
+
     - surface tilt
     - surface azimuth
     - the DC capacity of the system
@@ -500,11 +501,11 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     power_ac : Series
         AC power from the system in clear sky conditions.
     ghi : Series
-        Clear sky GHI at the same times as `power_ac`
+        Clear sky GHI with same index as `power_ac`.
     dhi : Series
-        Clear sky DHI.
+        Clear sky DHI with same index as `power_ac`.
     dni : Series
-        Clear sky DNI.
+        Clear sky DNI with same index as `power_ac`.
     solar_zenith : Series
         Solar zenith. [degrees]
     solar_azimuth : Series
@@ -519,8 +520,8 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     temperature_model_parameters : dict, optional
         Parameters fot the cell temperature model. If not specified
         ``pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS['sapm'][
-        'open_rack_glass_glass'] is used. See
-        :py:func`pvlib.temperature.sapm_cell` for more information.
+        'open_rack_glass_glass']`` is used. See
+        :py:func:`pvlib.temperature.sapm_cell` for more information.
 
     Returns
     -------

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -407,8 +407,9 @@ def infer_orientation_daily_peak(power_or_poa, sunny, tilts,
 
 def _power_residuals_from_clearsky(system_params,
                                    ghi, dhi, dni,
+                                   power_ac,
                                    solar_zenith, solar_azimuth,
-                                   power_ac, temperature,
+                                   temperature,
                                    wind_speed,
                                    temperature_coefficient,
                                    temperature_model_parameters):
@@ -426,12 +427,12 @@ def _power_residuals_from_clearsky(system_params,
         Clear sky DHI
     dni : Series
         Clear sky DNI
+    power_ac : Series
+        Measured AC power under clear sky conditions.
     solar_zenith : Series
         Solar zenith at the same times as data in `power_ac`
     solar_azimuth : Series
         Solar azimuth at the same times as data in `power_ac`
-    power_ac : Series
-        Measured AC power under clear sky conditions.
     temperature : float or Series
         Air temperature at which to model the hypothetical system. If a
         float then a constant temperature is used. If a Series, must have

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -482,7 +482,7 @@ def _rsquared(data, residuals):
 def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
                             solar_zenith, solar_azimuth,
                             temperature=25, wind_speed=0,
-                            temperature_coefficient=-0.002,
+                            temperature_coefficient=-0.004,
                             temperature_model_parameters=None):
     """Get the tilt and azimuth that give pvwatts output that most closely
     fits the data in `power_ac`.

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -413,8 +413,8 @@ def _power_residuals_from_clearsky(system_params,
                                    wind_speed,
                                    temperature_coefficient,
                                    temperature_model_parameters):
-    """Return the residuals between a system with parameters given in `system_params`
-    and the data in `power_ac`.
+    """Return the residuals between a system with parameters given in
+    `system_params` and the data in `power_ac`.
 
     Parameters
     ----------
@@ -450,12 +450,12 @@ def _power_residuals_from_clearsky(system_params,
     Series
         Difference between `power_ac` and the PVWatts output with the
         given parameters.
-    
+
     Notes
     ------
-    Uses the defaults in `pvlib.irradiance.get_total_irradiance` to calculated plane-of-array
-    irradiance, i.e., the isotropic model for sky diffuse irradiance, and the Perez irradiance
-    transposition model.
+    Uses the defaults in :py:func:`pvlib.irradiance.get_total_irradiance` to
+    calculated plane-of-array irradiance, i.e., the isotropic model for sky
+    diffuse irradiance, and the Perez irradiance transposition model.
     """
     tilt = system_params[0]
     azimuth = system_params[1]
@@ -499,7 +499,7 @@ def infer_orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
 
     Input data `power_ac`, `ghi`, `dhi`, `dni` should reflect clear-sky
     conditions.
-    
+
     Uses non-linear least squares to optimize over four free variables
     to find the values that result in the best fit between power modeled
     using PVWatts and `power_ac`. The four free variables are

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -496,7 +496,9 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     - the DC capacity of the system
     - the DC input limit of the inverter.
 
-    All parameters passed as a Series must have the same index.
+    All parameters passed as a Series must have the same index and must not
+    contain any undefined values (i.e. NaNs). If any input contains NaNs a
+    ValueError is raised.
 
     Parameters
     ----------
@@ -534,17 +536,19 @@ def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
     r_squared : float
         :math:`r^2` value for the fit at the returned orientation.
 
+    Raises
+    ------
+    ValueError
+        If any input passed as a Series contains undefined values (i.e. NaNs).
     """
-    power_ac = power_ac.dropna()
-    ghi = ghi.dropna()
-    dhi = dhi.dropna()
-    dni = dni.dropna()
-    solar_azimuth = solar_azimuth.dropna()
-    solar_zenith = solar_zenith.dropna()
-    if isinstance(temperature, pd.Series):
-        temperature = temperature.dropna()
-    if isinstance(wind_speed, pd.Series):
-        wind_speed = wind_speed.dropna()
+    if power_ac.hasnans:
+        raise ValueError("power_ac must not contain undefined values")
+    if ghi.hasnans or dhi.hasnans or dni.hasnans:
+        raise ValueError("ghi, dhi, and dni must not contain undefined values")
+    if isinstance(temperature, pd.Series) and temperature.hasnans:
+        raise ValueError("temperature must not contain undefined values")
+    if isinstance(wind_speed, pd.Series) and wind_speed.hasnans:
+        raise ValueError("wind_speed must not contain undefined values")
     if temperature_model_parameters is None:
         temperature_model_parameters = \
             TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -451,7 +451,7 @@ def _power_residuals_from_clearsky(system_params,
     tilt = system_params[0]
     azimuth = system_params[1]
     dc_capacity = system_params[2]
-    dc_limit = system_params[3]
+    dc_inverter_limit = system_params[3]
     poa = pvlib.irradiance.get_total_irradiance(
         tilt, azimuth,
         solar_zenith,
@@ -470,7 +470,7 @@ def _power_residuals_from_clearsky(system_params,
         dc_capacity,
         temperature_coefficient
     )
-    return power_ac - pvlib.inverter.pvwatts(pdc, dc_limit)
+    return power_ac - pvlib.inverter.pvwatts(pdc, dc_inverter_limit)
 
 
 def _rsquared(data, residuals):

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -2,8 +2,10 @@
 import enum
 import warnings
 import numpy as np
+import scipy
 import pandas as pd
 import pvlib
+from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
 from pvanalytics.util import _fit, _group
 
 
@@ -401,3 +403,159 @@ def infer_orientation_daily_peak(power_or_poa, sunny, tilts,
                 best_azimuth = azimuth
                 best_tilt = tilt
     return best_azimuth, best_tilt
+
+
+def _power_residuals_from_clearsky(system_params,
+                                   ghi, dhi, dni,
+                                   solar_zenith, solar_azimuth,
+                                   power_ac, temperature,
+                                   wind_speed,
+                                   temperature_coefficient,
+                                   temperature_model_parameters):
+    # Return the residuals between a system with parameters given in `params`
+    # and the data in `power_ac`.
+    #
+    # Parameters
+    # ----------
+    # system_params : array-like
+    #     array of four floats: tilt, azimuth, DC capacity, and inverter
+    #     DC input limit.
+    # ghi : Series
+    #     Clear sky GHI
+    # dhi : Series
+    #     Clear sky DHI
+    # dni : Series
+    #     Clear sky DNI
+    # solar_zenith : Series
+    #     Solar zenith at the same times as data in `power_ac`
+    # solar_azimuth : Series
+    #     Solar azimuth at the same times as data in `power_ac`
+    # power_ac : Series
+    #     Measured AC power under clear sky conditions.
+    # temperature : float or Series
+    #     Air temperature at which to model the hypothetical system. If a
+    #     float then a constant temperature is used. If a Series, must have
+    #     the same index as `power_ac`. [C]
+    # wind_speed : float or Series
+    #     Wind speed. If a float then a constant wind speed is used. If a
+    #     Series, must have the same index as `power_ac`. [m/s]
+    # temperature_model_parameters : dict
+    #     Parameters fot the cell temperature model.
+    #
+    # Returns
+    # -------
+    # Series
+    #     Difference between `power_ac` and the PVWatts output with the
+    #     given parameters.
+    tilt = system_params[0]
+    azimuth = system_params[1]
+    dc_capacity = system_params[2]
+    dc_limit = system_params[3]
+    poa = pvlib.irradiance.get_total_irradiance(
+        tilt, azimuth,
+        solar_zenith,
+        solar_azimuth,
+        dni, ghi, dhi
+    )
+    temp_cell = pvlib.temperature.sapm_cell(
+        poa['poa_global'],
+        temperature,
+        wind_speed,
+        **temperature_model_parameters
+    )
+    pdc = pvlib.pvsystem.pvwatts_dc(
+        poa['poa_global'],
+        temp_cell,
+        dc_capacity,
+        temperature_coefficient
+    )
+    return power_ac - pvlib.inverter.pvwatts(pdc, dc_limit)
+
+
+def _rsquared(data, residuals):
+    # Calculate the coefficient of determination from `residuals`
+    model = data + residuals
+    _, _, r, _, _ = scipy.stats.linregress(model, data)
+    return r*r
+
+
+def orientation_fit_pvwatts(power_ac, ghi, dhi, dni,
+                            solar_zenith, solar_azimuth,
+                            temperature=25, wind_speed=0,
+                            temperature_coefficient=-0.002,
+                            temperature_model_parameters=None):
+    """Get the tilt and azimuth that give pvwatts output that most closely
+    fits the data in `power_ac`.
+
+    Uses non-linear least squares to optimize over four free variables
+    to find the values that result in the best fit between power modeled
+    using PVWatts and `power_ac`. The four free variables are
+    - surface tilt
+    - surface azimuth
+    - the DC capacity of the system
+    - the DC input limit of the inverter.
+
+    Parameters
+    ----------
+    power_ac : Series
+        AC power from the system in clear sky conditions.
+    ghi : Series
+        Clear sky GHI at the same times as `power_ac`
+    dhi : Series
+        Clear sky DHI.
+    dni : Series
+        Clear sky DNI.
+    solar_zenith : Series
+        Solar zenith. [degrees]
+    solar_azimuth : Series
+        Solar azimuth. [degrees]
+    temperature : float or Series, default 25
+        Air temperature at which to model the hypothetical system. If a
+        float then a constant temperature is used. If a Series, must have
+        the same index as `power_ac`. [C]
+    wind_speed : float or Series, default 0
+        Wind speed. If a float then a constant wind speed is used. If a
+        Series, must have the same index as `power_ac`. [m/s]
+    temperature_model_parameters : dict, optional
+        Parameters fot the cell temperature model. If not specified
+        ``pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS['sapm'][
+        'open_rack_glass_glass'] is used. See
+        :py:func`pvlib.temperature.sapm_cell` for more information.
+
+    Returns
+    -------
+    surface_tilt : float
+        Tilt of the array. [degrees]
+    surface_azimuth : float
+        Azimuth of the array. [degrees]
+    r_squared : float
+        :math:`r^2` value for the fit at the returned orientation.
+
+    """
+    if temperature_model_parameters is None:
+        temperature_model_parameters = \
+            TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
+    initial_tilt = 45
+    initial_azimuth = 180
+    initial_dc_capacity = power_ac.max()
+    initial_dc_limit = power_ac.max() * 1.5
+    fit_result = scipy.optimize.least_squares(
+        _power_residuals_from_clearsky,
+        [initial_tilt, initial_azimuth, initial_dc_capacity, initial_dc_limit],
+        bounds=([0, 0, power_ac.max()*0.5, power_ac.max()*0.5],
+                [90, 360, power_ac.max()*2, power_ac.max()*3]),
+        kwargs={
+            'ghi': ghi,
+            'dhi': dhi,
+            'dni': dni,
+            'solar_zenith': solar_zenith,
+            'solar_azimuth': solar_azimuth,
+            'power_ac': power_ac,
+            'temperature': temperature,
+            'temperature_coefficient': temperature_coefficient,
+            'wind_speed': wind_speed,
+            'temperature_model_parameters': temperature_model_parameters
+        }
+    )
+    r_squared = _rsquared(power_ac, fit_result.fun)
+    return fit_result.x[0], fit_result.x[1], r_squared

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -2,7 +2,8 @@
 import pytest
 import numpy as np
 import pandas as pd
-from pvlib import location
+from pvlib import location, pvsystem
+from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
 
 
 def pytest_addoption(parser):
@@ -99,3 +100,20 @@ def clearsky_year(one_year_hourly, albuquerque):
 def solarposition_year(one_year_hourly, albuquerque):
     """One year of solar position data in albuquerque"""
     return albuquerque.get_solarposition(one_year_hourly)
+
+
+@pytest.fixture(scope='module')
+def system_parameters():
+    """System parameters for generating simulated power data."""
+    sandia_modules = pvsystem.retrieve_sam('SandiaMod')
+    sapm_inverters = pvsystem.retrieve_sam('cecinverter')
+    module = sandia_modules['Canadian_Solar_CS5P_220M___2009_']
+    inverter = sapm_inverters['ABB__MICRO_0_25_I_OUTD_US_208__208V_']
+    temperature_model_parameters = (
+        TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
+    )
+    return {
+        'module_parameters': module,
+        'inverter_parameters': inverter,
+        'temperature_model_parameters': temperature_model_parameters
+    }

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -1,26 +1,8 @@
 import pytest
 from pandas.util.testing import assert_series_equal
 import pandas as pd
-from pvlib import pvsystem, tracking, modelchain, irradiance
-from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
+from pvlib import tracking, modelchain, irradiance
 from pvanalytics.features import orientation
-
-
-@pytest.fixture(scope='module')
-def system_parameters():
-    """System parameters for generating simulated power data."""
-    sandia_modules = pvsystem.retrieve_sam('SandiaMod')
-    sapm_inverters = pvsystem.retrieve_sam('cecinverter')
-    module = sandia_modules['Canadian_Solar_CS5P_220M___2009_']
-    inverter = sapm_inverters['ABB__MICRO_0_25_I_OUTD_US_208__208V_']
-    temperature_model_parameters = (
-        TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
-    )
-    return {
-        'module_parameters': module,
-        'inverter_parameters': inverter,
-        'temperature_model_parameters': temperature_model_parameters
-    }
 
 
 def test_clearsky_ghi_fixed(clearsky, solarposition):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.16.0
 pandas>=0.25.0,<1.1.0
-pvlib>=0.7.0
+pvlib>=0.8.0
 scipy>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ TESTS_REQUIRE = [
 INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
     'pandas >= 0.25.1',
-    'pvlib >= 0.7.0',
+    'pvlib >= 0.8.0',
     'scipy >= 1.3.0'
 ]
 


### PR DESCRIPTION
## Description

Implements method for identifying tilt and azimuth given AC power, clear sky irradiance, and solar position.

## Checklist

- [x] Added new API functions to `docs/api.rst`
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] Pull request is nearly complete and ready for detailed review
