### PR TITLE
Look for daylight savings shifts across specific dates

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -121,12 +121,13 @@ spacing, time-shifts, and time zone validation.
    quality.time.spacing
 
 Timestamp shifts, such as daylight savings, can be identified with
-the following funcitons.
+the following functions.
 
 .. autosummary::
    :toctree: generated/
 
    quality.time.shifts_ruptures
+   quality.time.has_dst
 
 Utilities
 ---------

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -201,7 +201,7 @@ def dst_dates(dates, tz):
     Returns
     -------
     Series
-        Boolean Series with True on days where daylight savins transitions
+        Boolean Series with True on days where daylight savings transitions
         occur.
     """
     midnight = pd.Series(
@@ -263,8 +263,9 @@ def has_dst(events, tz, window=7, min_difference=45):
     events : Series
         Series with one timestamp for each day. The timestamp should
         correspond to an event that occurs at roughly the same time on
-        each day, and shifts with daylight savings transitions. For example,
-        you may pass sunrise, sunset, or solar transit time.
+        each day. For example,
+        you may pass sunrise, sunset, or solar transit time. `events` need
+        not be localized.
     tz : str
         Name of a timezone that observes daylight savings and has the same
         or similar UTC offset as the expected time zone for `events`.

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -228,7 +228,7 @@ def _has_dst(events, date, window, min_difference):
     window : Timedelta
         Number of days before and after `date` to use when checking for
         for shifts in `events`
-    min_different : int
+    min_difference : int
         Minimum difference between mean event time before `date` and mean
         event time after `date` for a shift tom be detected.
 

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -225,7 +225,7 @@ def _has_dst(events, date, window, min_difference):
     date : Timestamp
         Timestamp corresponding to midnight on the day to check for daylight
         savings shifts.
-    window : int
+    window : Timedelta
         Number of days before and after `date` to use when checking for
         for shifts in `events`
     min_different : int

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -253,10 +253,11 @@ def has_dst(events, tz, window=7, min_difference=45):
     at the dates on which `tz` transitions to or from daylight savings
     time.
 
-    Compares the mean event time in minutes since midnight over the
-    `window` days before and after each date in `shift_dates`. If the
-    difference is greater than `min_difference` then a shift has occurred
-    on that date.
+    The mean event time in minutes since midnight is calculated
+    over the `window` days before and after the date of each daylight
+    savings transition in `tz`. For each date, the two mean event times
+    (before and after) are compared, and if the difference is greater
+    than `min_difference` then a shift has occurred on that date.
 
     Parameters
     ----------

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -304,7 +304,7 @@ def has_dst(events, tz, window=7, min_difference=45, missing='raise'):
         If there is no data in the `window` days before or after a shift
         date in `events`.
     """
-    shift_dates = dst_dates(events.index, tz)
+    shift_dates = dst_dates(events.asfreq('D', fill_value=pd.NaT).index, tz)
     # Build a series of transition dates
     shift_dates = shift_dates[shift_dates]
     shift_dates = shift_dates.index.to_series(index=shift_dates.index)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -292,14 +292,8 @@ def has_dst(events, tz, window=7, min_difference=45):
         `events`.
     """
     # Build a timestamp at noon on each day in the data
-    s = pd.Series(
-        pd.DatetimeIndex(events.index.tz_localize(None).date),
-        index=events.index
-    )
-    s = s + pd.Timedelta(hours=12)
-    s = s.dt.tz_localize(tz)
-    dst_shift = s.apply(lambda t: t.tzinfo.dst(t).total_seconds() / 3600)
-    shift_dates = s[dst_shift.diff().fillna(0) != 0]
+    shift_dates = dst_dates(events.index, tz)
+    shift_dates = shift_dates[shift_dates]  # keep only the transition dates
     if len(shift_dates) == 0:
         raise ValueError("No daylight savings shifts in expected "
                          f"timezone ({tz}) on dates in input")
@@ -312,4 +306,4 @@ def has_dst(events, tz, window=7, min_difference=45):
             window,
             min_difference
         )
-    ).astype('bool')
+    ).astype('bool').reindex(events.index, fill_value=False)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -211,9 +211,10 @@ def _has_dst(events, date, window, min_difference):
         detected in the the event times on `date`.
     """
     before = events[date - window:date - pd.Timedelta(days=1)]
-    after = events[date:date + window]
+    after = events[date:date + window - pd.Timedelta(days=1)]
     if len(before) == 0 or len(after) == 0:
-        raise ValueError(f"Insufficient data at {date}.")
+        raise ValueError(f"No data at {date}. "
+                         "Consider passing a larger `window`.")
     before = before.dt.hour * 60 + before.dt.minute
     after = after.dt.hour * 60 + after.dt.minute
     return abs(before.mean() - after.mean()) > min_difference

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -249,8 +249,9 @@ def _has_dst(events, date, window, min_difference):
 
 
 def has_dst(events, tz, window=7, min_difference=45):
-    """Return true if `events` appears to have daylight-savings shifts
-    at the dates in `shift_dates`.
+    """Return True if `events` appears to have daylight savings shifts
+    at the dates on which `tz` transitions to or from daylight savings
+    time.
 
     Compares the mean event time in minutes since midnight over the
     `window` days before and after each date in `shift_dates`. If the
@@ -280,23 +281,19 @@ def has_dst(events, tz, window=7, min_difference=45):
     Returns
     -------
     Series
-        Boolean Series indexed by dates on which Daylight Savings transitions
-        are expected to occur in `tz` and True if a shift was found on that
-        date in `events`
+        Boolean Series with the same index as `events` True for dates that
+        appear to have daylight savings transitions.
 
     Raises
     ------
     ValueError
-        If there is no data before or after a shift date or there are no
-        daylight-savings shifts in `tz` for the dates covered by
-        `events`.
+        If there is no data in the `window` days before or after a shift
+        date in `events`.
     """
-    # Build a timestamp at noon on each day in the data
     shift_dates = dst_dates(events.index, tz)
-    shift_dates = shift_dates[shift_dates]  # keep only the transition dates
-    if len(shift_dates) == 0:
-        raise ValueError("No daylight savings shifts in expected "
-                         f"timezone ({tz}) on dates in input")
+    # Build a series of transition dates
+    shift_dates = shift_dates[shift_dates]
+    shift_dates = shift_dates.index.to_series(index=shift_dates.index)
     window = pd.Timedelta(days=window)
     events = events.dropna()
     return shift_dates.apply(

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -45,17 +45,33 @@ def _has_dst(event_times, date, window, min_difference):
 
 def has_dst(event_times, shift_dates, window=7, min_difference=45):
     """Return true if `daynight_mask` appears to have daylight-savings shifts
-    at or near the dates in `shift_dates`.
+    at the dates in `shift_dates`.
+
+    Compares the mean event time in minutes since midnight over the
+    `window` days before and after each date in `shift_dates`. If the
+    difference is greater than `min_difference` then a shift has occurred
+    on that date.
 
     Parameters
     ----------
     event_times : Series
-        Series with one timestamp for each day.
+        Series with one timestamp for each day. The timestamp should
+        correspond to an event that occurs at roughly the same time on
+        each day, and shifts with daylight savings transitions. For example,
+        you may pass sunrise, sunset, or solar transit time.
     shift_dates : list of datetime-like
-        Dates of expected daylight savings time shifts. String should be in
-        a format that can be parsed by :py:func:`pandas.to_datetime`.
-    window : int
-        Number of days before and after the shift date to consider.
+        Dates of expected daylight savings time shifts. Can be any type
+        that can be converted to a ``pandas.Timestamp`` by
+        :py:func:`pandas.to_datetime`.
+    window : int, default 7
+        Number of days before and after the shift date to consider. When
+        passing rounded timestamps in `event_times` it may be necessary to
+        use a smaller window. [days]
+    min_difference : int, default 45
+        Minimum difference between the mean event time before the shift
+        date and the mean event time after the event time. If the difference
+        is greater than `min_difference` a shift has occurred on that date.
+        [minutes]
 
     Returns
     -------

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -186,6 +186,34 @@ def shifts_ruptures(event_times, reference_times, period_min=2,
     return shift_amount != 0, shift_amount
 
 
+def dst_dates(dates, tz):
+    """
+    Get the dates on which daylight savings transitions occur in
+    the timezone `tz`.
+
+    Parameters
+    ----------
+    dates : DatetimeIndex
+        A datetime index with one timestamp per day.
+    tz : str
+        A timezone string (e.g. 'America/Denver' or 'CET')
+
+    Returns
+    -------
+    Series
+        Boolean Series with True on days where daylight savins transitions
+        occur.
+    """
+    midnight = pd.Series(
+        pd.DatetimeIndex(dates.tz_localize(None).date),
+        index=dates
+    )
+    noon = midnight + pd.Timedelta(hours=12)
+    noon = noon.dt.tz_localize(tz)
+    dst_shift = noon.apply(lambda t: t.tzinfo.dst(t).total_seconds() / 3600)
+    return dst_shift.diff().fillna(0) != 0
+
+
 def _has_dst(events, date, window, min_difference):
     """Return True if `events` appears to have a daylight savings shift
     on `date`.

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -187,6 +187,29 @@ def shifts_ruptures(event_times, reference_times, period_min=2,
 
 
 def _has_dst(events, date, window, min_difference):
+    """Return True if `events` appears to have a daylight savings shift
+    on `date`.
+
+    Parameters
+    ----------
+    events : Series
+        Series of timestamps, one per day.
+    date : Timestamp
+        Timestamp corresponding to midnight on the day to check for daylight
+        savings shifts.
+    window : int
+        Number of days before and after `date` to use when checking for
+        for shifts in `events`
+    min_different : int
+        Minimum difference between mean event time before `date` and mean
+        event time after `date` for a shift tom be detected.
+
+    Returns
+    -------
+    bool
+        Whether or not a shift of at least `min_difference` minutes was
+        detected in the the event times on `date`.
+    """
     before = events[date - window:date - pd.Timedelta(days=1)]
     after = events[date:date + window]
     if len(before) == 0 or len(after) == 0:

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -71,7 +71,7 @@ def _get_sunrise(location, tz):
     ).sunrise
 
 
-@pytest.mark.parametrize("tz, observes_dst", [#('MST', False),
+@pytest.mark.parametrize("tz, observes_dst", [('MST', False),
                                               ('America/Denver', True)])
 def test_has_dst(tz, observes_dst, albuquerque):
     sunrise = _get_sunrise(albuquerque, tz)
@@ -430,6 +430,31 @@ def test_shifts_ruptures_tz_localized(midday):
             0, index=midday.index.tz_localize(None), dtype='int64'
         ),
         check_names=False
+    )
+
+
+@pytest.mark.parametrize("timezone, expected_dates",
+                         [('America/Denver', ('2020-03-08', '2020-11-01')),
+                          ('CET', ('2020-03-29', '2020-10-25')),
+                          ('MST', tuple())])
+def test_dst_dates(timezone, expected_dates):
+    index = pd.date_range(
+        start='2020-01-01',
+        end='2020-12-31',
+        freq='D',
+        tz='America/Chicago'
+    )
+    dates = time.dst_dates(
+        index,
+        timezone
+    )
+    expected = pd.Series(False, index=index)
+    expected[expected_dates] = True
+    assert_series_equal(dates, expected)
+    # Test without timezone information.
+    assert_series_equal(
+        time.dst_dates(index.tz_localize(None), timezone),
+        expected.tz_localize(None)
     )
 
 

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -77,7 +77,8 @@ def test_has_dst(tz, observes_dst, albuquerque):
     sunrise = _get_sunrise(albuquerque, tz)
     dst = time.has_dst(sunrise, 'America/Denver')
     expected = pd.Series(False, index=sunrise.index)
-    expected.loc[['2020-03-08', '2020-11-01']] = observes_dst
+    expected.loc['2020-03-08'] = observes_dst
+    expected.loc['2020-11-01'] = observes_dst
     assert_series_equal(
         expected,
         dst,
@@ -91,7 +92,8 @@ def test_has_dst_input_series_not_localized(tz, observes_dst, albuquerque):
     sunrise = _get_sunrise(albuquerque, tz)
     sunrise = sunrise.tz_localize(None)
     expected = pd.Series(False, index=sunrise.index)
-    expected.loc[['2020-03-08 00:00', '2020-11-01 00:00']] = observes_dst
+    expected.loc['2020-03-08'] = observes_dst
+    expected.loc['2020-11-01'] = observes_dst
     dst = time.has_dst(sunrise, 'America/Denver')
     assert_series_equal(
         expected,
@@ -108,7 +110,8 @@ def test_has_dst_rounded(tz, freq, observes_dst, albuquerque):
     # days we look at.
     window = 7 if freq != 'H' else 1
     expected = pd.Series(False, index=sunrise.index)
-    expected.loc[['2020-03-08 00:00', '2020-11-01 00:00']] = observes_dst
+    expected.loc['2020-03-08'] = observes_dst
+    expected.loc['2020-11-01'] = observes_dst
     dst = time.has_dst(
         sunrise.dt.round(freq),
         'America/Denver',
@@ -143,17 +146,17 @@ def test_has_dst_missing_data(albuquerque):
 
 def test_has_dst_no_dst_in_date_range(albuquerque):
     sunrise = _get_sunrise(albuquerque, 'America/Denver')
-    july = sunrise['2020-07']
-    march = sunrise['2020-03']
+    july = sunrise['2020-07-01':'2020-07-31']
+    february = sunrise['2020-02-01':'2020-03-05']
     expected_july = pd.Series(False, index=july.index)
-    expected_march = pd.Series(False, index=march.index)
+    expected_march = pd.Series(False, index=february.index)
     assert_series_equal(
         expected_july,
         time.has_dst(july, 'America/Denver')
     )
     assert_series_equal(
         expected_march,
-        time.has_dst(march, 'MST')
+        time.has_dst(february, 'MST')
     )
 
 
@@ -434,9 +437,9 @@ def test_shifts_ruptures_tz_localized(midday):
 
 
 @pytest.mark.parametrize("timezone, expected_dates",
-                         [('America/Denver', ('2020-03-08', '2020-11-01')),
-                          ('CET', ('2020-03-29', '2020-10-25')),
-                          ('MST', tuple())])
+                         [('America/Denver', ['2020-03-08', '2020-11-01']),
+                          ('CET', ['2020-03-29', '2020-10-25']),
+                          ('MST', [])])
 def test_dst_dates(timezone, expected_dates):
     index = pd.date_range(
         start='2020-01-01',
@@ -449,7 +452,8 @@ def test_dst_dates(timezone, expected_dates):
         timezone
     )
     expected = pd.Series(False, index=index)
-    expected[expected_dates] = True
+    for date in expected_dates:
+        expected[date] = True
     assert_series_equal(dates, expected)
     # Test without timezone information.
     assert_series_equal(

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -132,9 +132,22 @@ def test_has_dst_missing_data(albuquerque):
     sunrise.loc['3/5/2020':'3/10/2020'] = pd.NaT
     # Doesn't raise since both sides still have some data
     _ = time.has_dst(sunrise, 'America/Denver')
-    sunrise.loc['3/1/2020':'3/5/2020'] = pd.NaT
-    with pytest.raises(ValueError, match='Insufficient data at .*'):
-        _ = time.has_dst(sunrise, 'America/Denver')
+    missing_all_before = sunrise.copy()
+    missing_all_after = sunrise.copy()
+    missing_all_before.loc['3/1/2020':'3/5/2020'] = pd.NaT
+    missing_all_after.loc['3/8/2020':'3/14/2020'] = pd.NaT
+    missing_data_message = r'No data at .*\. ' \
+                           r'Consider passing a larger `window`.'
+    # Raises for missing data before transition date
+    with pytest.raises(ValueError, match=missing_data_message):
+        time.has_dst(missing_all_before, 'America/Denver')
+    # Raises for missing data after transition date
+    with pytest.raises(ValueError, match=missing_data_message):
+        time.has_dst(missing_all_after, 'America/Denver')
+    # Raises for missing data before and after the shift date
+    sunrise.loc['3/1/2020':'3/14/2020'] = pd.NaT
+    with pytest.raises(ValueError, match=missing_data_message):
+        time.has_dst(sunrise, 'America/Denver')
 
 
 def test_has_dst_no_dst_in_date_range(albuquerque):

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -107,7 +107,7 @@ def test_has_dst_rounded(tz, freq, observes_dst, albuquerque):
     # With rounding to 1-hour timestamps we need to reduce how many
     # days we look at.
     window = 7 if freq != 'H' else 1
-    expected = pd.Series(False, index=sunrise.index.tz_localize(tz))
+    expected = pd.Series(False, index=sunrise.index)
     expected.loc[['2020-03-08 00:00', '2020-11-01 00:00']] = observes_dst
     dst = time.has_dst(
         sunrise.dt.round(freq),

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -56,3 +56,20 @@ def test_timestamp_spacing_too_frequent(times):
         time.spacing(times, '30min'),
         pd.Series([True] + [False] * (len(times) - 1), index=times)
     )
+
+
+@pytest.mark.parametrize("tz", ['MST', 'America/Denver'])
+def test_has_dst(tz, albuquerque):
+    days = pd.date_range(
+        start='1/1/2020',
+        end='1/1/2021',
+        freq='D',
+        tz=tz
+    )
+    sunrise = albuquerque.get_sun_rise_set_transit(
+        days, method='spa')['sunrise']
+    dst = time.has_dst(sunrise, ['3/8/2020', '11/1/2020'])
+    if tz == 'America/Denver':
+        assert dst == [True, True]
+    else:
+        assert dst == [False, False]

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -95,6 +95,17 @@ def test_has_dst_rounded(tz, freq, expected, albuquerque):
     assert dst == [expected, expected]
 
 
+def test_has_dst_missing_data(albuquerque):
+    sunrise = _get_sunrise(albuquerque, 'MST')
+    sunrise.loc['1/1/2020':'1/10/2020'] = pd.NaT
+    sunrise.loc['3/5/2020':'3/10/2020'] = pd.NaT
+    # Doesn't raise since both sides still have some data
+    _ = time.has_dst(sunrise, ['3/8/2020', '11/1/2020']) == [True, True]
+    sunrise.loc['3/1/2020':'3/5/2020'] = pd.NaT
+    with pytest.raises(ValueError, match=r'Insufficient data at .*'):
+        _ = time.has_dst(sunrise, ['3/8/2020'])
+
+
 @pytest.fixture(scope='module', params=['H', '15T', 'T'])
 def midday(request, albuquerque):
     solar_position = albuquerque.get_solarposition(

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -149,16 +149,29 @@ def test_has_dst_missing_data(albuquerque):
     sunrise.loc['3/9/2020':'3/14/2020'] = pd.NaT
     with pytest.raises(ValueError, match=missing_data_message):
         time.has_dst(sunrise, 'America/Denver')
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=missing_data_message):
         result = time.has_dst(sunrise, 'America/Denver', missing='warn')
     expected.loc['3/8/2020'] = False
     assert_series_equal(expected, result)
     sunrise.loc['3/1/2020':'3/14/2020'] = pd.NaT
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=missing_data_message):
         result = time.has_dst(sunrise, 'America/Denver', missing='warn')
     assert_series_equal(expected, result)
     with pytest.raises(ValueError, match=missing_data_message):
         time.has_dst(sunrise, 'America/Denver')
+
+
+def test_has_dst_gaps(albuquerque):
+    sunrise = _get_sunrise(albuquerque, 'America/Denver')
+    sunrise.loc['3/5/2020':'3/10/2020'] = pd.NaT
+    sunrise.loc['7/1/2020':'7/20/2020'] = pd.NaT
+    sunrise.dropna(inplace=True)
+    expected = pd.Series(False, index=sunrise.index)
+    expected['11/1/2020'] = True
+    assert_series_equal(
+        time.has_dst(sunrise, 'America/Denver'),
+        expected
+    )
 
 
 def test_has_dst_no_dst_in_date_range(albuquerque):


### PR DESCRIPTION
## Description

Given the dates on which daylight savings transitions occur, determine whether a series has DST by testing for a large shift between sunrise time in the week before and after the shift date.

## Checklist

- [x] Closes #66
- [x] Added new API functions to `docs/api.rst`
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] Pull request is nearly complete and ready for detailed review
