### PR TITLE
Use scipy.stats.median_abs_deviation in outliers.hampel

### DIFF
--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -95,6 +95,7 @@ def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
     median = data.rolling(window=window, center=True).median()
     deviation = abs(data - median)
     mad = data.rolling(window=window, center=True).apply(
-        stats.median_absolute_deviation
+        stats.median_abs_deviation,
+        kwargs={'scale': 'normal'}
     )
-    return deviation > max_deviation * scale * mad
+    return deviation > max_deviation * mad * scale

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.16.0
 pandas>=0.25.0,<1.1.0
 pvlib>=0.8.0
-scipy>=1.3.0
+scipy>=1.5.0
 ruptures[optional]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
     'pandas >= 0.25.1',
     'pvlib >= 0.8.0',
-    'scipy >= 1.3.0'
+    'scipy >= 1.5.0'
 ]
 
 DOCS_REQUIRE = [


### PR DESCRIPTION
scipy.stats.median_absolute_deviation is deprecated in version 1.5

## Checklist

- [x] Closes #80 
- [x] Pull request is nearly complete and ready for detailed review
