### PR TITLE
Reduce duplicate code for converting freqstr to Timedelta

### DIFF
--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -1,6 +1,7 @@
 """Functions for identifying clipping."""
 import pandas as pd
 import numpy as np
+from pvanalytics import util
 
 
 def _detect_levels(x, count=3, num_bins=100):
@@ -130,9 +131,10 @@ def _clipping_power(ac_power, slope_max, power_min,
     #
     # Based on the PVFleets QA Analysis project
     if not freq:
-        freq = pd.Timedelta(pd.infer_freq(ac_power.index)).seconds / 60
+        freq = util.freq_to_timedelta(
+            pd.infer_freq(ac_power.index)).seconds / 60
     elif isinstance(freq, str):
-        freq = pd.Timedelta(freq).seconds / 60
+        freq = util.freq_to_timedelta(freq).seconds / 60
 
     # Use the slope of the 99.5% quantile of daytime power at
     # each minute to identify clipping.

--- a/pvanalytics/features/daytime.py
+++ b/pvanalytics/features/daytime.py
@@ -1,7 +1,7 @@
 """Functions for identifying daytime"""
 import numpy as np
 import pandas as pd
-from pandas.tseries import frequencies
+from pvanalytics import util
 
 
 def _rolling_by_minute(data, days, f):
@@ -103,9 +103,7 @@ def _filter_and_normalize(series, outliers):
 
 
 def _freqstr_to_minutes(freqstr):
-    return pd.to_timedelta(
-        frequencies.to_offset(freqstr)
-    ).seconds / 60
+    return util.freq_to_timedelta(freqstr).seconds / 60
 
 
 def power_or_irradiance(series, outliers=None,

--- a/pvanalytics/features/orientation.py
+++ b/pvanalytics/features/orientation.py
@@ -1,6 +1,6 @@
 """Functions for identifying system orientation."""
 import pandas as pd
-from pandas.tseries import frequencies
+from pvanalytics import util
 from pvanalytics.util import _fit, _group
 
 
@@ -56,7 +56,7 @@ def _conditional_fit(day, minutes, fitfunc, freq, default=0.0, min_hours=0.0,
 
 def _freqstr_to_hours(freq):
     # Convert pandas freqstr to hours (as a float)
-    return pd.to_timedelta(frequencies.to_offset(freq)).seconds / 3600
+    return util.freq_to_timedelta(freq).seconds / 3600
 
 
 def _hours(data, freq):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -7,6 +7,8 @@ values (i.e. 999).
 import numpy as np
 import pandas as pd
 
+from pvanalytics import util
+
 
 def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
     """Test if all values in x are close to x[0].
@@ -247,9 +249,7 @@ def interpolation_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
 
 
 def _freq_to_seconds(freq):
-    if freq.isalpha():
-        freq = '1' + freq
-    delta = pd.to_timedelta(freq)
+    delta = util.freq_to_timedelta(freq)
     return delta.days * (1440 * 60) + delta.seconds
 
 

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -6,7 +6,8 @@ from scipy import integrate
 from pvlib.tools import cosd
 import pvlib
 
-from pvanalytics.quality import util
+from pvanalytics import quality
+from pvanalytics import util
 
 
 QCRAD_LIMITS = {'ghi_ub': {'mult': 1.5, 'exp': 1.2, 'min': 100},
@@ -82,7 +83,7 @@ def check_ghi_limits_qcrad(ghi, solar_zenith, dni_extra, limits=None):
         limits = QCRAD_LIMITS
     ghi_ub = _qcrad_ub(dni_extra, solar_zenith, limits['ghi_ub'])
 
-    ghi_limit_flag = util.check_limits(ghi, limits['ghi_lb'], ghi_ub)
+    ghi_limit_flag = quality.util.check_limits(ghi, limits['ghi_lb'], ghi_ub)
 
     return ghi_limit_flag
 
@@ -129,7 +130,7 @@ def check_dhi_limits_qcrad(dhi, solar_zenith, dni_extra, limits=None):
 
     dhi_ub = _qcrad_ub(dni_extra, solar_zenith, limits['dhi_ub'])
 
-    dhi_limit_flag = util.check_limits(dhi, limits['dhi_lb'], dhi_ub)
+    dhi_limit_flag = quality.util.check_limits(dhi, limits['dhi_lb'], dhi_ub)
 
     return dhi_limit_flag
 
@@ -176,7 +177,7 @@ def check_dni_limits_qcrad(dni, solar_zenith, dni_extra, limits=None):
 
     dni_ub = _qcrad_ub(dni_extra, solar_zenith, limits['dni_ub'])
 
-    dni_limit_flag = util.check_limits(dni, limits['dni_lb'], dni_ub)
+    dni_limit_flag = quality.util.check_limits(dni, limits['dni_lb'], dni_ub)
 
     return dni_limit_flag
 
@@ -272,10 +273,12 @@ def _check_irrad_ratio(ratio, ghi, sza, bounds):
     ghi_lb, ghi_ub, sza_lb, sza_ub, ratio_lb, ratio_ub = _get_bounds(bounds)
     # for zenith set inclusive_lower to handle edge cases, e.g., zenith=0
     return (
-        util.check_limits(sza, lower_bound=sza_lb,
-                          upper_bound=sza_ub, inclusive_lower=True)
-        & util.check_limits(ghi, lower_bound=ghi_lb, upper_bound=ghi_ub)
-        & util.check_limits(ratio, lower_bound=ratio_lb, upper_bound=ratio_ub)
+        quality.util.check_limits(
+            sza, lower_bound=sza_lb, upper_bound=sza_ub, inclusive_lower=True)
+        & quality.util.check_limits(
+            ghi, lower_bound=ghi_lb, upper_bound=ghi_ub)
+        & quality.util.check_limits(
+            ratio, lower_bound=ratio_lb, upper_bound=ratio_ub)
     )
 
 
@@ -391,13 +394,13 @@ def clearsky_limits(measured, clearsky, csi_max=1.1):
         clearsky,
         max_clearsky_index=np.Inf
     )
-    return util.check_limits(csi, upper_bound=csi_max, inclusive_upper=True)
+    return quality.util.check_limits(
+        csi, upper_bound=csi_max, inclusive_upper=True
+    )
 
 
 def _to_hours(freqstr):
-    if freqstr[0].isalpha():
-        freqstr = '1' + freqstr
-    return pd.to_timedelta(freqstr).seconds / 3600
+    return util.freq_to_timedelta(freqstr).seconds / 3600
 
 
 def _daily_total(series):
@@ -462,7 +465,7 @@ def daily_insolation_limits(irrad, clearsky, daily_min=0.4, daily_max=1.25):
     """
     daily_irradiance = _daily_total(irrad)
     daily_clearsky = _daily_total(clearsky)
-    good_days = util.check_limits(
+    good_days = quality.util.check_limits(
         daily_irradiance/daily_clearsky,
         upper_bound=daily_max,
         lower_bound=daily_min

--- a/pvanalytics/util/__init__.py
+++ b/pvanalytics/util/__init__.py
@@ -1,2 +1,3 @@
-from pvanalytics.util import _fit    # noqa: F401
-from pvanalytics.util import _group  # noqa: F401
+from pvanalytics.util import _fit                          # noqa: F401
+from pvanalytics.util import _group                        # noqa: F401
+from pvanalytics.util._functions import freq_to_timedelta  # noqa: F401

--- a/pvanalytics/util/_functions.py
+++ b/pvanalytics/util/_functions.py
@@ -4,14 +4,15 @@ from pandas.tseries import frequencies
 
 
 def freq_to_timedelta(freq):
-    """Convert a pandas freqstr to a timedelta
+    """Convert a pandas freqstr to a Timedelta.
 
     Parameters
     ----------
     freq : str
-
+        A pandas freqstr (e.g. '10T').
     Returns
     -------
     Timedelta
+        Timedelta corresponding to a single period at `freq`.
     """
     return pd.to_timedelta(frequencies.to_offset(freq))

--- a/pvanalytics/util/_functions.py
+++ b/pvanalytics/util/_functions.py
@@ -1,0 +1,17 @@
+"""General purpose utility functions."""
+import pandas as pd
+from pandas.tseries import frequencies
+
+
+def freq_to_timedelta(freq):
+    """Convert a pandas freqstr to a timedelta
+
+    Parameters
+    ----------
+    freq : str
+
+    Returns
+    -------
+    Timedelta
+    """
+    return pd.to_timedelta(frequencies.to_offset(freq))


### PR DESCRIPTION
Reduces duplicate code and removes brittle DIY solution, replacing it with calls to `pandas.tseries.frequencies.to_offset()`.

In looking at #83 I found that the older version of pandas does not work for the freqstr to timedelta conversion that was implemented previously. Good opportunity to refactor and reduce code duplication.

## Checklist

- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] ~Added tests to cover all new or modified code~ (covered by existing tests)
- [x] Pull request is nearly complete and ready for detailed review
