### PR TITLE
Use statsmodels for maximum absolute deviation

### DIFF
--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -60,7 +60,7 @@ def zscore(data, zmax=1.5):
     return pd.Series((abs(stats.zscore(data)) > zmax), index=data.index)
 
 
-def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
+def hampel(data, window=5, max_deviation=3.0, scale=None):
     r"""Identify outliers by the Hampel identifier.
 
     The Hampel identifier is computed according to [1]_.
@@ -75,10 +75,12 @@ def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
     max_deviation : float, default 3.0
         Any value with a Hampel identifier > `max_deviation` standard
         deviations from the median is considered an outlier.
-    scale : float, default 1.4826
-        MAD scale estimate. The standard deviation is calculated as
-        :math:`scale * MAD`. The default gives an estimate for the
-        standard deviation of Gaussian distributed data.
+    scale : float, optional
+        Scale factor used to estimate the standard deviation as
+        :math:`MAD / scale`. If `scale=None` (default), then the scale
+        factor is taken to be ``scipy.stats.norm.ppf(3/4.)`` (approx. 0.6745),
+        and :math:`MAD / scale` approximates the standard deviation
+        of Gaussian distributed data.
 
     Returns
     -------
@@ -95,8 +97,11 @@ def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
     """
     median = data.rolling(window=window, center=True).median()
     deviation = abs(data - median)
+    kwargs = {}
+    if scale is not None:
+        kwargs = {'c': scale}
     mad = data.rolling(window=window, center=True).apply(
         robust.scale.mad,
-        kwargs={'c': 1.0/scale}
+        kwargs=kwargs
     )
     return deviation > max_deviation * mad

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -1,6 +1,7 @@
 """Functions for identifying and labeling outliers."""
 import pandas as pd
 from scipy import stats
+from statsmodels import robust
 
 
 def tukey(data, k=1.5):
@@ -95,6 +96,6 @@ def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
     median = data.rolling(window=window, center=True).median()
     deviation = abs(data - median)
     mad = data.rolling(window=window, center=True).apply(
-        stats.median_absolute_deviation
+        robust.scale.mad
     )
     return deviation > max_deviation * scale * mad

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -96,6 +96,7 @@ def hampel(data, window=5, max_deviation=3.0, scale=1.4826):
     median = data.rolling(window=window, center=True).median()
     deviation = abs(data - median)
     mad = data.rolling(window=window, center=True).apply(
-        robust.scale.mad
+        robust.scale.mad,
+        kwargs={'c': 1.0/scale}
     )
-    return deviation > max_deviation * scale * mad
+    return deviation > max_deviation * mad

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -137,3 +137,12 @@ def test_hampel_max_deviation():
         data[outliers.hampel(data, window=11, max_deviation=16)],
         data[expected]
     )
+
+
+def test_hampel_scale():
+    np.random.seed(1000)
+    data = pd.Series(np.random.uniform(-1, 1, size=100))
+    data.iloc[20] = -25
+    data.iloc[40] = 15
+    data.iloc[60] = 5
+    assert not all(outliers.hampel(data) == outliers.hampel(data, scale=0.1))

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -128,12 +128,12 @@ def test_hampel_max_deviation():
 
     expected.iloc[60] = False
     assert_series_equal(
-        data[outliers.hampel(data, window=11, max_deviation=10)],
+        data[outliers.hampel(data, window=11, max_deviation=15)],
         data[expected]
     )
 
     expected.iloc[40] = False
     assert_series_equal(
-        data[outliers.hampel(data, window=11, max_deviation=12)],
+        data[outliers.hampel(data, window=11, max_deviation=16)],
         data[expected]
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy>=1.16.0
 pandas>=0.25.0,<1.1.0
 pvlib>=0.8.0
 scipy>=1.3.0
+statsmodels>=0.9.0
 ruptures[optional]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.0
 pandas>=0.25.0,<1.1.0
 pvlib>=0.8.0
-scipy>=1.3.0
+scipy>=1.2.0
 statsmodels>=0.9.0
 ruptures[optional]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
     'pandas >= 0.25.1',
     'pvlib >= 0.8.0',
-    'scipy >= 1.3.0'
+    'scipy >= 1.3.0',
+    'statsmodels >= 0.9.0'
 ]
 
 DOCS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
     'pandas >= 0.25.1',
     'pvlib >= 0.8.0',
-    'scipy >= 1.3.0',
+    'scipy >= 1.2.0',
     'statsmodels >= 0.9.0'
 ]
 


### PR DESCRIPTION
Rather than `scipy.stats.maximum_absolute_deviation()` we will use `statsmodels.robust.scale.mad()` to calculate the Maximum Absolute Deviation. This change will let us lower the minimum scipy version to 1.2 `scipy.stats.maximum_absolute_deviation()` was introduces in 1.3 (see #83).

## Checklist

- [x] Closes #80 
- [x] Pull request is nearly complete and ready for detailed review
