### PR TITLE
Apply NEP-29 guidelines for dependencies

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,6 +9,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
+        requirements: [requirements.txt]
+        include:
+          - requirements: requirements-min.txt
+            python-version: 3.6
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -18,10 +23,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install dependencies in ${{ matrix.requirements }}
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r ${{ matrix.requirements }} .[all]
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 install:
   - pip install pytest==5.4.3 pytest-cov coveralls
   - pip install -r requirements.txt
+  - pip install .[all]
 
 script:
   - pytest --cov=pvanalytics --cov-config=.coveragerc --cov-report term-missing pvanalytics --runslow

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,7 @@ It supports:
   and at minimum the two latest minor versions.
 - All minor versions of numpy released in the 24 months prior to the project,
   and at minimum the last three minor versions
+- The latest release of `PVLib <https://pvlib-python.readthedocs.io>`_.
 
 PVAnalytics depends on the following packages:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,9 @@ library status.
 Dependencies
 ------------
 
-This project follows the guidelines laid out in NEP-29. It supports:
+This project follows the guidelines laid out in
+`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
+It supports:
 
 - All minor versions of Python released 42 months prior to the project,
   and at minimum the two latest minor versions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,20 @@ system-level data.
 The source code for PVAnalytics is hosted on `github
 <https://github.com/pvlib/pvanalytics>`_.
 
+Dependencies
+------------
+
+This project follows the guidelines laid out in NEP-29. It supports:
+
+- All minor versions of Python released 42 months prior to the project,
+  and at minimum the two latest minor versions.
+- All minor versions of numpy released in the 24 months prior to the project,
+  and at minimum the last three minor versions
+
+PVAnalytics depends on the following packages:
+
+.. literalinclude:: ../requirements.txt
+
 Contents
 ========
 

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -323,4 +323,4 @@ def has_dst(events, tz, window=7, min_difference=45, missing='raise'):
     # of all False.
     if len(shifted) == 0:
         return pd.Series(False, index=events.index)
-    return shifted.reindex(events.index, fill_value=False)
+    return shifted.astype('bool').reindex(events.index, fill_value=False)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -321,6 +321,6 @@ def has_dst(events, tz, window=7, min_difference=45, missing='raise'):
     # pandas 0.23 won't allow .astype('bool') and empty Series with
     # dtype='datetime64[ns]'. Work around this by building a new series
     # of all False.
-    if len(shifted) == 0:
+    if shifted.empty:
         return pd.Series(False, index=events.index)
     return shifted.astype('bool').reindex(events.index, fill_value=False)

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,5 @@
+numpy~=1.15.0
+pandas~=0.23.0
+pvlib~=0.8.0
+scipy~=1.2.0
+statsmodels~=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.16.0
-pandas>=0.25.0,<1.1.0
+numpy>=1.15.0
+pandas>=0.23.0,<1.1.0
 pvlib>=0.8.0
 scipy>=1.2.0
 statsmodels>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pandas>=0.23.0,<1.1.0
 pvlib>=0.8.0
 scipy>=1.2.0
 statsmodels>=0.9.0
-ruptures[optional]

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ TESTS_REQUIRE = [
 ]
 
 INSTALL_REQUIRES = [
-    'numpy >= 1.16.0',
-    'pandas >= 0.25.1',
+    'numpy >= 1.15.0',
+    'pandas >= 0.23.0',
     'pvlib >= 0.8.0',
     'scipy >= 1.2.0',
     'statsmodels >= 0.9.0'


### PR DESCRIPTION
Lowers minimum required version of pandas and numpy. Adds a CI job to test against the minimum version for all dependencies and fixes one bug related to the lower pandas version.

## Checklist

- [x] Closes #83 
- [x] Pull request is nearly complete and ready for detailed review
