### PR TITLE
Revert pull_request_target trigger to pull_request

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,6 +1,6 @@
 name: lint and test
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
I mis-read the documentation on this. pull_request_target builds against the base workflow _and_ code. That is not the behavior I want, since it means the build does not test new code.
