### PR TITLE
updated outliers.zscore to include nan_policy

### DIFF
--- a/docs/whatsnew/0.1.1.rst
+++ b/docs/whatsnew/0.1.1.rst
@@ -16,6 +16,9 @@ Enhancements
 Bug Fixes
 ~~~~~~~~~
 
+* Added nan_policy to zscore calculation
+  :py:func:`pvanalytics.quality.outliers.zscore`.
+
 Contributors
 ~~~~~~~~~~~~
 

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -71,8 +71,8 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
         elif nan_policy == 'omit':
             nan_mask = data.isna()
         else:
-            raise ValueError("Incorrect specification passed. "
-                             "Expected `raise` or `omit`.")
+            raise ValueError(f"Unnexpected value ({nan_policy}) passed to nan_policy. "
+                             "Expected 'raise' or 'omit'.")
 
     data[~nan_mask] = pd.Series(abs(stats.zscore(data[~nan_mask])) > zmax,
                                 index=data[~nan_mask].index)

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -61,8 +61,8 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
 
     """
     return pd.Series((abs(stats.zscore(data,
-                                       nan_policy=nan_policy)) > zmax),
-                                       index=data.index)
+                                       nan_policy=nan_policy))
+                      > zmax), index=data.index)
 
 
 def hampel(data, window=5, max_deviation=3.0, scale=None):

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -71,8 +71,9 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
         elif nan_policy == 'omit':
             nan_mask = data.isna()
         else:
-            raise ValueError(f"Unnexpected value ({nan_policy}) passed to nan_policy. "
-                             "Expected 'raise' or 'omit'.")
+            raise ValueError(f"Unnexpected value ({nan_policy}) "
+                             "passed to nan_policy. Expected "
+                             "'raise' or 'omit'.")
 
     data[~nan_mask] = pd.Series(abs(stats.zscore(data[~nan_mask])) > zmax,
                                 index=data[~nan_mask].index)

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -71,9 +71,8 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
         elif nan_policy == 'omit':
             nan_mask = data.isna()
         else:
-            raise ValueError(f"Unnexpected value ({nan_policy}) "
-                             "passed to nan_policy. Expected "
-                             "'raise' or 'omit'.")
+            raise ValueError(f"Unnexpected value ({nan_policy}) passed to "
+                             "nan_policy. Expected 'raise' or 'omit'.")
 
     data[~nan_mask] = pd.Series(abs(stats.zscore(data[~nan_mask])) > zmax,
                                 index=data[~nan_mask].index)

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -71,8 +71,8 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
         elif nan_policy == 'omit':
             nan_mask = data.isna()
         else:
-            raise ValueError("Incorrect specification passed " +
-                             "to zscore's nan_policy.")
+            raise ValueError("Incorrect specification passed. "
+                             "Expected `raise` or `omit`.")
 
     data[~nan_mask] = pd.Series(abs(stats.zscore(data[~nan_mask])) > zmax,
                                 index=data[~nan_mask].index)

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -38,7 +38,7 @@ def tukey(data, k=1.5):
             | (data > (third_quartile + k*iqr)))
 
 
-def zscore(data, zmax=1.5):
+def zscore(data, zmax=1.5, nan_policy = 'raise'):
     """Identify outliers using the z-score.
 
     Points with z-score greater than `zmax` are considered as outliers.
@@ -49,6 +49,9 @@ def zscore(data, zmax=1.5):
         A series of numeric values in which to find outliers.
     zmax : float
         Upper limit of the absolute values of the z-score.
+    nan_policy : str
+        Define how to handle NaNs in the input series, inputs should be
+        consistent with scipy.
 
     Returns
     -------
@@ -57,7 +60,9 @@ def zscore(data, zmax=1.5):
         outlier.
 
     """
-    return pd.Series((abs(stats.zscore(data)) > zmax), index=data.index)
+    return pd.Series((abs(stats.zscore(data, 
+                                       nan_policy=nan_policy)) > zmax), 
+                                       index=data.index)
 
 
 def hampel(data, window=5, max_deviation=3.0, scale=None):

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -38,7 +38,7 @@ def tukey(data, k=1.5):
             | (data > (third_quartile + k*iqr)))
 
 
-def zscore(data, zmax=1.5, nan_policy = 'raise'):
+def zscore(data, zmax=1.5, nan_policy='raise'):
     """Identify outliers using the z-score.
 
     Points with z-score greater than `zmax` are considered as outliers.
@@ -60,8 +60,8 @@ def zscore(data, zmax=1.5, nan_policy = 'raise'):
         outlier.
 
     """
-    return pd.Series((abs(stats.zscore(data, 
-                                       nan_policy=nan_policy)) > zmax), 
+    return pd.Series((abs(stats.zscore(data,
+                                       nan_policy=nan_policy)) > zmax),
                                        index=data.index)
 
 

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -51,6 +51,13 @@ def test_zscore_raise_nan_input():
         outliers.zscore(data, nan_policy='raise')
 
 
+def test_zscore_invalid_nan_policy():
+    data = pd.Series([1, 0, -1, 0, np.NaN, 1, -1, 10])
+
+    with pytest.raises(ValueError):
+        outliers.zscore(data, nan_policy='incorrect_str')
+
+
 def test_zscore_omit_nan_input():
     data = pd.Series([1, 0, -1, 0, np.NaN, 1, -1, 10])
     assert_series_equal(

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -43,6 +43,25 @@ def test_tukey_lower_criteria():
     )
 
 
+def test_zscore_raise_nan_input():
+    data = pd.Series([1, 0, -1, 0, np.NaN, 1, -1, 10])
+
+    try:
+        outliers.zscore(data, nan_policy='raise')
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+
+def test_zscore_omit_nan_input():
+    data = pd.Series([1, 0, -1, 0, np.NaN, 1, -1, 10])
+    assert_series_equal(
+        pd.Series([False, False, False, False, False, False, False, True]),
+        outliers.zscore(outliers.zscore(data, nan_policy='omit'))
+    )
+
+
 def test_zscore_all_same():
     """If all data is identical there are no outliers."""
     data = pd.Series([1 for _ in range(20)])

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -1,4 +1,5 @@
 """Tests for the quality.outliers module."""
+import pytest
 import pandas as pd
 import numpy as np
 from pandas.util.testing import assert_series_equal
@@ -46,12 +47,8 @@ def test_tukey_lower_criteria():
 def test_zscore_raise_nan_input():
     data = pd.Series([1, 0, -1, 0, np.NaN, 1, -1, 10])
 
-    try:
+    with pytest.raises(ValueError):
         outliers.zscore(data, nan_policy='raise')
-    except ValueError:
-        assert True
-    else:
-        assert False
 
 
 def test_zscore_omit_nan_input():


### PR DESCRIPTION
## Description

An update to `outliers.zscore` to expose the nan_policy.

## Checklist

The following items must be addressed before the code can be merged. 
Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
*You are free to remove any checklist items that do not apply or add additional items that are 
not on this list*

- [x] Closes #102
- [ ] Added new API functions to `docs/api.rst`
- [ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [ ] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] Pull request is nearly complete and ready for detailed review
