### PR TITLE
Update test suite for pvlib v0.9.0

### DIFF
--- a/pvanalytics/tests/features/test_clearsky.py
+++ b/pvanalytics/tests/features/test_clearsky.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pvanalytics.features import clearsky
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.skip(reason="GH #105")
 @pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
 def test_reno_identical(quadratic):
     """Identical clearsky and measured irradiance all True"""
@@ -14,7 +14,7 @@ def test_reno_identical(quadratic):
     assert clearsky.reno(quadratic, quadratic).all()
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.skip(reason="GH #105")
 @pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in")
 def test_reno_begining_end(quadratic):

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -46,7 +46,6 @@ def power_tracking(clearsky, albuquerque, system_parameters):
     mc = modelchain.ModelChain(
         system,
         albuquerque,
-        orientation_strategy='south_at_latitude_tilt'
     )
     mc.run_model(clearsky)
     return mc.ac

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -52,11 +52,12 @@ def summer_ghi(summer_clearsky):
 @pytest.fixture
 def summer_power_fixed(summer_clearsky, albuquerque, system_parameters):
     """Simulated power from a FIXED PVSystem in Albuquerque, NM."""
-    pv_system = pvsystem.PVSystem(**system_parameters)
+    pv_system = pvsystem.PVSystem(surface_azimuth=180,
+                                  surface_tilt=albuquerque.latitude,
+                                  **system_parameters)
     mc = modelchain.ModelChain(
         pv_system,
         albuquerque,
-        orientation_strategy='south_at_latitude_tilt'
     )
     mc.run_model(summer_clearsky)
     return mc.ac
@@ -64,12 +65,11 @@ def summer_power_fixed(summer_clearsky, albuquerque, system_parameters):
 
 @pytest.fixture
 def summer_power_tracking(summer_clearsky, albuquerque, system_parameters):
-    """Simulated power for a pvlib SingleAxisTracker PVSystem in Albuquerque"""
+    """Simulated power for a TRACKING PVSystem in Albuquerque"""
     pv_system = tracking.SingleAxisTracker(**system_parameters)
     mc = modelchain.ModelChain(
         pv_system,
-        albuquerque,
-        orientation_strategy='south_at_latitude_tilt'
+        albuquerque
     )
     mc.run_model(summer_clearsky)
     return mc.ac


### PR DESCRIPTION
## Description

This PR updates the test suite to not use the `orientation_strategy` ModelChain parameter (removed in v0.9.0).  Here is an example failed CI run from #114: https://github.com/pvlib/pvanalytics/runs/4398633530?check_suite_focus=true

At some point we will need to stop using `SingleAxisTracker` as well, but it still works for now.

## Checklist

The following items must be addressed before the code can be merged. 
Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
*You are free to remove any checklist items that do not apply or add additional items that are 
not on this list*

- ~Closes #xxx~
- ~Added new API functions to `docs/api.rst`~
- ~Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings~
- [ ] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- ~Non-API functions clearly documented with docstrings or comments as necessary~
- ~Added tests to cover all new or modified code~
- [x] Pull request is nearly complete and ready for detailed review
