### PR TITLE
Update pandas requirements

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-10.15, windows-latest]  # macos-latest does not have py3.6
         python-version: [3.6, 3.7, 3.8]
         requirements: [requirements.txt]
         include:

--- a/docs/whatsnew/0.1.1.rst
+++ b/docs/whatsnew/0.1.1.rst
@@ -20,7 +20,10 @@ Bug Fixes
 ~~~~~~~~~
 
 * Added nan_policy to zscore calculation
-  :py:func:`pvanalytics.quality.outliers.zscore`.
+  :py:func:`pvanalytics.quality.outliers.zscore`. (:issue:`102`, :pull:`108`)
+* Prohibit pandas versions in the 1.1.x series to avoid an issue in
+  ``.groupby().rolling()``.  Newer versions starting in 1.2.0 and older
+  versions going back to 0.24.0 are still allowed. (:issue:`82`, :pull:`118`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.15.0
-pandas>=0.24.0,<1.1.0
+pandas>=0.24.0,!=1.1.*
 pvlib>=0.8.0
 scipy>=1.2.0
 statsmodels>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ TESTS_REQUIRE = [
 
 INSTALL_REQUIRES = [
     'numpy >= 1.15.0',
-    'pandas >= 0.24.0',
+    'pandas >= 0.24.0, != 1.1.*',
     'pvlib >= 0.8.0',
     'scipy >= 1.2.0',
     'statsmodels >= 0.9.0',


### PR DESCRIPTION
## Description

This PR updates the requirements spec to prohibit `pandas==1.1.*`.  I figured there was little point in cooking up a workaround that works on all pandas versions because there were only ~6 months between 1.0.5 and 1.2.0 and it's been about a year since 1.2.0 was released.

I tested a range of pandas versions locally (windows) before opening this PR and include the results for reference:
- `pandas==1.1.0`: access violation/segfault
- `pandas>=1.1.1,<=1.1.5`: test failure
- `pandas>=1.2.0`: pass

## Checklist

- [x] Closes #82
- ~Added new API functions to `docs/api.rst`~
- ~Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- ~Non-API functions clearly documented with docstrings or comments as necessary~
- ~Added tests to cover all new or modified code~
- [x] Pull request is nearly complete and ready for detailed review
