### PR TITLE
Get clearsky.reno tests passing again

### DIFF
--- a/docs/whatsnew/0.1.1.rst
+++ b/docs/whatsnew/0.1.1.rst
@@ -24,6 +24,8 @@ Bug Fixes
 * Prohibit pandas versions in the 1.1.x series to avoid an issue in
   ``.groupby().rolling()``.  Newer versions starting in 1.2.0 and older
   versions going back to 0.24.0 are still allowed. (:issue:`82`, :pull:`118`)
+* Fixed an issue with :py:func:`pvanalytics.features.clearsky.reno` in recent
+  pandas versions (:issue:`125`, :pull:`128`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/pvanalytics/features/clearsky.py
+++ b/pvanalytics/features/clearsky.py
@@ -62,7 +62,7 @@ def reno(ghi, ghi_clearsky):
 
     """
     delta = ghi.index.to_series().diff()
-    delta_minutes = delta[1] / np.timedelta64(1, '60s')
+    delta_minutes = delta[1].total_seconds() / 60
     if delta_minutes > 15:
         raise ValueError('clearsky requires regular time intervals '
                          'of 15m or less')

--- a/pvanalytics/tests/features/test_clearsky.py
+++ b/pvanalytics/tests/features/test_clearsky.py
@@ -1,10 +1,14 @@
 """Tests for feature labeling functions."""
 import pytest
 import pandas as pd
+import pvlib
 from pvanalytics.features import clearsky
 
+from pkg_resources import parse_version
+is_old_pvlib = parse_version(pvlib.__version__) < parse_version("0.9.0")
 
-@pytest.mark.skip(reason="GH #105")
+
+@pytest.mark.skipif(is_old_pvlib, reason="GH #105")
 @pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
 def test_reno_identical(quadratic):
     """Identical clearsky and measured irradiance all True"""
@@ -14,7 +18,7 @@ def test_reno_identical(quadratic):
     assert clearsky.reno(quadratic, quadratic).all()
 
 
-@pytest.mark.skip(reason="GH #105")
+@pytest.mark.skipif(is_old_pvlib, reason="GH #105")
 @pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in")
 def test_reno_begining_end(quadratic):


### PR DESCRIPTION
## Description

The sphinx build in #127 is failing because of #126, and I figured might as well fix #105 while we're at it.  

## Checklist

- [x] Partially addresses #105
- [x] Closes #126
- ~[ ] Added new API functions to `docs/api.rst`~
- ~[ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- ~[ ] Non-API functions clearly documented with docstrings or comments as necessary~
- ~[ ] Added tests to cover all new or modified code~
- [x] Pull request is nearly complete and ready for detailed review
