### PR TITLE
Delete requirements.txt; related CI & test changes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ${{ matrix.requirements }} .[test]
+        pip install ${{ matrix.requirements }} .[test,optional]
     - name: Test with pytest
       run: |
         pytest --cov=pvanalytics --cov-config=.coveragerc --cov-report term-missing pvanalytics --runslow

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]
-        requirements: [requirements.txt]
+        requirements: ['']
         include:
-          - requirements: requirements-min.txt
+          - requirements: "-r requirements-min.txt"
             python-version: 3.7
             os: ubuntu-latest
 
@@ -23,13 +23,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies in ${{ matrix.requirements }}
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r ${{ matrix.requirements }} .[all]
+        pip install ${{ matrix.requirements }} .[test]
     - name: Test with pytest
       run: |
-        pip install pytest pytest-cov
         pytest --cov=pvanalytics --cov-config=.coveragerc --cov-report term-missing pvanalytics --runslow
     - name: Upload Coverage
       run: |
@@ -75,11 +74,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
+        python -m pip install --upgrade pip
         pip install flake8
         flake8 . --count --statistics --show-source

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,9 +82,6 @@ It supports:
   and at minimum the last three minor versions
 - The latest release of `PVLib <https://pvlib-python.readthedocs.io>`_.
 
-PVAnalytics depends on the following packages:
-
-.. literalinclude:: ../requirements.txt
 
 Contents
 ========

--- a/pvanalytics/tests/quality/test_data_shifts.py
+++ b/pvanalytics/tests/quality/test_data_shifts.py
@@ -62,6 +62,7 @@ def test_detect_data_shifts(generate_series):
     assert (len(shift_index_param.index) == len(signal_datetime_index.index))
 
 
+@requires_ruptures
 def test_get_longest_shift_segment_dates(generate_series):
     """
     Unit test that the longest interval between data shifts is selected for

--- a/pvanalytics/tests/quality/test_data_shifts.py
+++ b/pvanalytics/tests/quality/test_data_shifts.py
@@ -3,7 +3,6 @@ import pandas as pd
 import pytest
 from pvanalytics.quality import data_shifts as dt
 from ..conftest import DATA_DIR, requires_ruptures
-import ruptures
 
 
 test_file_1 = DATA_DIR / "pvlib_data_shift.csv"
@@ -28,6 +27,7 @@ def test_detect_data_shifts(generate_series):
     Unit test that data shifts are correctly identified in the simulated time
     series.
     """
+    import ruptures
     signal_no_index, signal_datetime_index, df_weekly_resample, \
         changepoint_date = generate_series
     # Test that an error is thrown when a Pandas series with no datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-numpy>=1.15.0
-pandas>=0.24.0,!=1.1.*
-pvlib>=0.8.0
-scipy>=1.2.0
-statsmodels>=0.9.0
-scikit-image>=0.16.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ URL = 'https://github.com/pvlib/pvanalytics'
 
 TESTS_REQUIRE = [
     'pytest',
+    'pytest-cov',
 ]
 
 INSTALL_REQUIRES = [


### PR DESCRIPTION
## Description

There are two main reasons we might want to have a requirements.txt:
- As an environment spec for users.  But pvanalytics is a library, not an application, so we prefer dependency ranges in `setup.py` over dependency versions in a requirements file.
- As an environment spec for testing, if you need specific versions beyond what's specified in setup.py.  We don't (currently) need that, so there's no need for a requirements.txt file either.  The exception is `requirements-min.txt`, which of course is not equivalent to setup.py.

This PR deletes `requirements.txt` so there's one less place to keep track of dependencies.  This required a bit of reworking of the CI configuration, which then uncovered some minor oversights in the tests.  

## Checklist

- [x] Closes #113
- [x] Pull request is nearly complete and ready for detailed review
