### PR TITLE
Stale data speedup

### DIFF
--- a/docs/whatsnew/0.1.3.rst
+++ b/docs/whatsnew/0.1.3.rst
@@ -9,7 +9,7 @@ Enhancements
 
 Bug Fixes
 ~~~~~~~~~
-* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, lead to the same results with a 300X speedup.
+* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, leading to the same results with a 300X speedup. (:issue:`156`, :pull:`158`)
 
 
 Requirements

--- a/docs/whatsnew/0.1.3.rst
+++ b/docs/whatsnew/0.1.3.rst
@@ -5,11 +5,11 @@
 
 Enhancements
 ~~~~~~~~~~~~
+* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, leading to the same results with a 300X speedup. (:issue:`156`, :pull:`158`)
 
 
 Bug Fixes
 ~~~~~~~~~
-* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, leading to the same results with a 300X speedup. (:issue:`156`, :pull:`158`)
 
 
 Requirements

--- a/docs/whatsnew/0.1.3.rst
+++ b/docs/whatsnew/0.1.3.rst
@@ -9,6 +9,7 @@ Enhancements
 
 Bug Fixes
 ~~~~~~~~~
+* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, lead to the same results with a 300X speedup.
 
 
 Requirements

--- a/docs/whatsnew/0.1.3.rst
+++ b/docs/whatsnew/0.1.3.rst
@@ -5,7 +5,7 @@
 
 Enhancements
 ~~~~~~~~~~~~
-* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas groupby() functionality, leading to the same results with a 300X speedup. (:issue:`156`, :pull:`158`)
+* Updated the :py:func:`~pvanalytics.gaps.stale_values_round` function with pandas functionality, leading to the same results with a 300X speedup. (:issue:`156`, :pull:`158`)
 
 
 Bug Fixes

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -12,6 +12,7 @@ from pvanalytics import util
 
 def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
     """Test if all values in x are close to x[0].
+
     Parameters
     ----------
     x : array
@@ -19,11 +20,14 @@ def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
         Tolerance for detecting a change relative to x[0].
     atol : float, default 1e-8
         Absolute tolerance for detecting a change from x[0].
+
     Parameters rtol and atol have the same meaning as in
     numpy.allclose.
+
     Returns
     -------
     Boolean
+
     Notes
     -----
     Copyright (c) 2019 SolarArbiter. See the file
@@ -31,6 +35,7 @@ def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
     of this distribution and at `<https://github.com/pvlib/
     pvanalytics/blob/master/LICENSES/SOLARFORECASTARBITER_LICENSE>`_
     for more information.
+
     """
     return np.allclose(a=x, b=x[0], rtol=rtol, atol=atol)
 
@@ -114,6 +119,7 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     """
     if window < 2:
         raise ValueError('window set to {}, must be at least 2'.format(window))
+
     flags = x.rolling(window=window).apply(
         _all_close_to_first,
         raw=True,

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -12,7 +12,6 @@ from pvanalytics import util
 
 def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
     """Test if all values in x are close to x[0].
-
     Parameters
     ----------
     x : array
@@ -20,14 +19,11 @@ def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
         Tolerance for detecting a change relative to x[0].
     atol : float, default 1e-8
         Absolute tolerance for detecting a change from x[0].
-
     Parameters rtol and atol have the same meaning as in
     numpy.allclose.
-
     Returns
     -------
     Boolean
-
     Notes
     -----
     Copyright (c) 2019 SolarArbiter. See the file
@@ -35,7 +31,6 @@ def _all_close_to_first(x, rtol=1e-5, atol=1e-8):
     of this distribution and at `<https://github.com/pvlib/
     pvanalytics/blob/master/LICENSES/SOLARFORECASTARBITER_LICENSE>`_
     for more information.
-
     """
     return np.allclose(a=x, b=x[0], rtol=rtol, atol=atol)
 
@@ -119,13 +114,12 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     """
     if window < 2:
         raise ValueError('window set to {}, must be at least 2'.format(window))
-
     flags = x.rolling(window=window).apply(
         _all_close_to_first,
         raw=True,
         kwargs={'rtol': rtol, 'atol': atol}
     ).fillna(False).astype(bool)
-    return _mark(flags, window, mark)
+    return mark(flags, window, mark)
 
 
 def stale_values_round(x, window=6, decimals=3, mark='tail'):
@@ -173,10 +167,11 @@ def stale_values_round(x, window=6, decimals=3, mark='tail'):
     (c) 2020 Alliance for Sustainable Energy, LLC.
 
     """
-    rounded_diff = x.round(decimals=decimals).diff()
-    endpoints = rounded_diff.rolling(window=window-1).apply(
-        lambda xs: len(xs[xs == 0]) == window-1
-    ).fillna(False).astype(bool)
+    rounded_x = x.round(decimals=decimals)
+    consecutive_val_counts = rounded_x.groupby((rounded_x !=
+                                                rounded_x.shift())
+                                               .cumsum()).cumcount()
+    endpoints = (~(consecutive_val_counts < window-1)) & ~(rounded_x.isna())
     return _mark(endpoints, window, mark)
 
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -119,7 +119,7 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
         raw=True,
         kwargs={'rtol': rtol, 'atol': atol}
     ).fillna(False).astype(bool)
-    return mark(flags, window, mark)
+    return _mark(flags, window, mark)
 
 
 def stale_values_round(x, window=6, decimals=3, mark='tail'):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -119,7 +119,6 @@ def stale_values_diff(x, window=6, rtol=1e-5, atol=1e-8, mark='tail'):
     """
     if window < 2:
         raise ValueError('window set to {}, must be at least 2'.format(window))
-
     flags = x.rolling(window=window).apply(
         _all_close_to_first,
         raw=True,
@@ -173,11 +172,8 @@ def stale_values_round(x, window=6, decimals=3, mark='tail'):
     (c) 2020 Alliance for Sustainable Energy, LLC.
 
     """
-    rounded_x = x.round(decimals=decimals)
-    consecutive_val_counts = rounded_x.groupby((rounded_x !=
-                                                rounded_x.shift())
-                                               .cumsum()).cumcount()
-    endpoints = (~(consecutive_val_counts < window-1)) & ~(rounded_x.isna())
+    rounded_diff = x.round(decimals=decimals).diff()
+    endpoints = (rounded_diff == 0).rolling(window=window-1).sum() == window-1
     return _mark(endpoints, window, mark)
 
 


### PR DESCRIPTION
## Description

*Thank you for your contribution! Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue)*

This PR speeds up the stale_data_round() function, by replacing the rolling + apply routine with a vectorized pandas routine.

## Checklist

The following items must be addressed before the code can be merged. 
Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
*You are free to remove any checklist items that do not apply or add additional items that are 
not on this list*

- [X] Closes #156 
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Non-API functions clearly documented with docstrings or comments as necessary
- [x] Added tests to cover all new or modified code
- [x] Pull request is nearly complete and ready for detailed review
