### PR TITLE
Fix `pvanalytics.__version__`

### DIFF
--- a/docs/whatsnew/0.1.4.rst
+++ b/docs/whatsnew/0.1.4.rst
@@ -15,7 +15,8 @@ Enhancements
 
 Bug Fixes
 ~~~~~~~~~
-
+* ``pvanalytics.__version__`` now correctly reports the version string instead
+  of raising ``AttributeError``. (:pull:`181`)
 
 Requirements
 ~~~~~~~~~~~~

--- a/pvanalytics/__init__.py
+++ b/pvanalytics/__init__.py
@@ -1,3 +1,15 @@
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    # for python < 3.8 (remove when dropping 3.7 support)
+    from importlib_metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = "0+unknown"
+
+
 from pvanalytics import features   # noqa: F401
 from pvanalytics import metrics    # noqa: F401
 from pvanalytics import quality    # noqa: F401

--- a/pvanalytics/tests/test_pvanalytics.py
+++ b/pvanalytics/tests/test_pvanalytics.py
@@ -1,0 +1,11 @@
+
+from pkg_resources import parse_version
+import pvanalytics
+
+
+def test___version__():
+    # check that the version string is determined correctly.
+    # if the version string is messed up for some reason, it should be
+    # '0+unknown', which is not greater than '0.0.1'.
+    version = parse_version(pvanalytics.__version__)
+    assert version > parse_version('0.0.1')

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ INSTALL_REQUIRES = [
     'pvlib >= 0.9.4',
     'scipy >= 1.4.0',
     'statsmodels >= 0.9.0',
-    'scikit-image >= 0.16.0'
+    'scikit-image >= 0.16.0',
+    'importlib-metadata; python_version < "3.8"',
 ]
 
 DOCS_REQUIRE = [


### PR DESCRIPTION
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Currently we aren't setting the `__version__` attribute in `__init__.py`, which means `pvanalytics.__version__` raises `AttributeError`.  This PR fixes that.