### PR TITLE
What's new cleanup for v0.2.0-alpha.1

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,7 +1,8 @@
 name: Upload to PyPi
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+    - "v*"
 
 jobs:
   deploy:

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -1,16 +1,20 @@
-.. _whatsnew_014:
+.. _whatsnew_020:
 
-0.1.4 (TBD)
--------------------------
+0.2.0 (anticipated March 2023)
+------------------------------
 
-Enhancements
-~~~~~~~~~~~~
+Breaking Changes
+~~~~~~~~~~~~~~~~
 * Updated function :py:func:`~pvanalytics.system.infer_orientation_fit_pvwatts`
   to more closely align with the PVWatts v5 methodology. This includes incorporating
   relative airmass and extraterrestrial irradiance into the Perez total irradiance model,
   accounting for array incidence loss (IAM), and including losses in the PVWatts
   inverter model. Additionally, added optional arguments for bounding the azimuth range in
   during least squares optimization. (:issue:`147`, :pull:`180`)
+
+
+Enhancements
+~~~~~~~~~~~~
 
 
 Bug Fixes
@@ -29,3 +33,5 @@ Documentation
 Contributors
 ~~~~~~~~~~~~
 * Kirsten Perry (:ghuser:`kperrynrel`)
+* Kevin Anderson (:ghuser:`kanderso-nrel`)
+* Cliff Hansen (:ghuser:`cwhanse`)

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -7,7 +7,7 @@ These are the bug-fixes, new features, and improvements for each release.
 .. toctree::
    :maxdepth: 2
 
-   0.1.4
+   0.2.0
    0.1.3
    0.1.2
    0.1.1


### PR DESCRIPTION
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/master/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Making a pre-release to support @kperrynrel's orientation estimation project.  Note that the `v0.2.0-alpha.1` name follows the recent pvlib convention; see https://github.com/pvlib/pvlib-python/tags

I've also changed the deploy-to-PyPI workflow to trigger on tags instead of GitHub Releases, with the thinking that we'll always make a tag when we want something to go to PyPI but we won't always want to make a GH Release (with pre-releases being an example).  