### PR TITLE
Compatibility with pandas 2.0.0

### DIFF
--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -21,11 +21,12 @@ Bug Fixes
 ~~~~~~~~~
 * ``pvanalytics.__version__`` now correctly reports the version string instead
   of raising ``AttributeError``. (:pull:`181`)
+* Compatibility with pandas 2.0.0 (:pull:`185`)
 
 Requirements
 ~~~~~~~~~~~~
 * Advance minimum ``pvlib`` to 0.9.4, ``numpy`` to 0.16.0,
-  ``pandas`` to 0.25.0, and ``scipy`` to 1.4.0. (:pull:`179`)
+  ``pandas`` to 1.0.0, and ``scipy`` to 1.4.0. (:pull:`179`, :pull:`185`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -38,3 +39,4 @@ Contributors
 * Kirsten Perry (:ghuser:`kperrynrel`)
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Abhishek Parikh (:ghuser:`abhisheksparikh`)

--- a/pvanalytics/metrics.py
+++ b/pvanalytics/metrics.py
@@ -81,7 +81,7 @@ def performance_ratio_nrel(poa_global, temp_air, wind_speed, pac, pdc0,
 def _calc_pathlength(signal, freq):
     # utility function to calculate the arc length of a time series.
     # used when calculating the variability index.
-    dt = signal.index.to_series(keep_tz=True).diff().dt.total_seconds()/60
+    dt = signal.index.to_series().diff().dt.total_seconds()/60
     dy = signal.diff()
     d = (dy**2 + dt**2)**0.5
     if freq is not None:

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -80,8 +80,7 @@ def quadratic():
 def one_year_hourly():
     return pd.date_range(
         start='03/01/2020',
-        end='03/01/2021',
-        closed='left',
+        end='02/28/2021 23:00',
         freq='H',
         tz='Etc/GMT+7'
     )
@@ -92,8 +91,7 @@ def three_days_hourly():
     """Three days with one hour timestamp spacing in Etc/GMT+7"""
     return pd.date_range(
         start='03/01/2020',
-        end='03/04/2020',
-        closed='left',
+        end='03/03/2020 23:00',
         freq='H',
         tz='Etc/GMT+7'
     )

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -1,6 +1,6 @@
 """Tests for features.clipping"""
 import pytest
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 import numpy as np
 import pandas as pd
 from pvlib import irradiance, temperature, pvsystem, inverter
@@ -320,7 +320,6 @@ def test_geometric_clipping_midday_clouds(power_pvwatts):
     power = power_pvwatts.resample('15T').asfreq()
     power.loc[power.between_time(
         start_time='17:30', end_time='19:30',
-        include_start=True, include_end=True
     ).index] = list(range(30, 39)) * 31
     clipped = clipping.geometric(power)
     expected = power == power.max()

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -1,5 +1,5 @@
 import pytest
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 import pandas as pd
 from pvlib import pvsystem, modelchain, irradiance
 from pvanalytics.features import orientation

--- a/pvanalytics/tests/features/test_shading.py
+++ b/pvanalytics/tests/features/test_shading.py
@@ -8,8 +8,7 @@ from pvanalytics.features import shading
 def times():
     return pd.date_range(
         start='1/1/2020',
-        end='12/31/2020',
-        closed='left',
+        end='12/31/2020 23:59',
         freq='T',
         tz='MST'
     )

--- a/pvanalytics/tests/quality/test_data_shifts.py
+++ b/pvanalytics/tests/quality/test_data_shifts.py
@@ -16,7 +16,7 @@ def generate_series():
     df.index = pd.to_datetime(df['timestamp'])
     signal_datetime_index = df['value']
     changepoint_date = df[df['label'] == 1].index[0]
-    df_weekly_resample = df.resample('W').median()['value']
+    df_weekly_resample = df['value'].resample('W').median()
     return (signal_no_index, signal_datetime_index,
             df_weekly_resample, changepoint_date)
 

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -2,7 +2,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 from pvanalytics.quality import gaps
 
 
@@ -431,7 +431,7 @@ def test_trim_incomplete_empty():
 def test_trim_daily_index():
     """trim works when data has a daily index."""
     data = pd.Series(True, index=pd.date_range(
-        start='1/1/2020', end='3/1/2020', freq='D', closed='left'))
+        start='1/1/2020', end='2/29/2020', freq='D'))
     assert gaps.trim(data).all()
     data.iloc[0:8] = False
     data.iloc[9] = False
@@ -533,9 +533,7 @@ def test_completeness_score_reindex():
     keep_index=True"""
     data = pd.Series(
         1,
-        index=pd.date_range(
-            start='1/1/2020', freq='15T', end='1/4/2020', closed='left'
-        )
+        index=pd.date_range(start='1/1/2020', freq='15T', end='1/3/2020 23:45')
     )
     data.loc[pd.date_range(start='1/1/2020', freq='30T', periods=48)] = np.nan
     data.loc[pd.date_range(start='1/3/2020', freq='1H', periods=24)] = np.nan
@@ -553,14 +551,13 @@ def test_completeness_score_reindex():
 def test_complete_threshold_zero():
     """minimum_completeness of 0 returns all True regardless of data."""
     ten_days = pd.date_range(
-        start='01/01/2020', freq='15T', end='1/10/2020', closed='left')
+        start='01/01/2020', freq='15T', end='1/09/2020 23:45')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(True, index=data.index),
         gaps.complete(data, minimum_completeness=0)
     )
-    data[pd.date_range(
-        start='01/01/2020', freq='1D', end='1/10/2020', closed='left')] = 1.0
+    data[pd.date_range(start='01/01/2020', freq='1D', end='1/09/2020')] = 1.0
     data.dropna()
     assert_series_equal(
         pd.Series(True, index=data.index),
@@ -577,7 +574,7 @@ def test_complete_threshold_one():
     """If minimum_completeness=1 then any missing data on a day means all
     data for the day is flagged False."""
     ten_days = pd.date_range(
-        start='01/01/2020', freq='15T', end='01/10/2020', closed='left')
+        start='01/01/2020', freq='15T', end='01/09/2020 23:45')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(False, index=data.index),
@@ -589,8 +586,7 @@ def test_complete_threshold_one():
         gaps.complete(data, minimum_completeness=1.0)
     )
     # remove one data-point per day
-    days = pd.date_range(
-        start='1/1/2020', freq='1D', end='1/10/2020', closed='left')
+    days = pd.date_range(start='1/1/2020', freq='1D', end='1/09/2020')
     data.loc[days] = np.nan
     assert_series_equal(
         pd.Series(False, index=data.index),
@@ -613,17 +609,17 @@ def test_complete_threshold_one():
 def test_complete():
     """Test gaps.complete with varying amounts of missing data."""
     ten_days = pd.date_range(
-        start='1/1/2020', freq='H', end='1/10/2020', closed='left')
+        start='1/1/2020', freq='H', end='1/10/2020 23:00')
     data = pd.Series(index=ten_days, dtype='float64')
     data.loc['1/1/2020'] = 1.0
     day_two_values = pd.date_range(
-        start='1/2/2020', freq='2H', end='1/3/2020', closed='left')
+        start='1/2/2020', freq='2H', end='1/2/2020 23:00')
     data.loc[day_two_values] = 2.0
     day_three_values = pd.date_range(
-        start='1/3/2020', freq='3H', end='1/4/2020', closed='left')
+        start='1/3/2020', freq='3H', end='1/3/2020 23:00')
     data.loc[day_three_values] = 3.0
     day_four_values = pd.date_range(
-        start='1/4/2020', freq='4H', end='1/5/2020', closed='left')
+        start='1/4/2020', freq='4H', end='1/4/2020 23:00')
     data.loc[day_four_values] = 4.0
     data.loc['1/5/2020':] = 5.0
 

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -4,7 +4,7 @@ import pytz
 import pandas as pd
 import numpy as np
 import pytest
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 from pvanalytics.quality import irradiance
 from ..conftest import DATA_DIR
 
@@ -276,8 +276,7 @@ def test_daily_insolation_limits(albuquerque):
     """Daily insolation limits works with uniform timestamp spacing."""
     three_days = pd.date_range(
         start='1/1/2020',
-        end='1/4/2020',
-        closed='left',
+        end='1/3/2020 23:00',
         freq='H'
     )
     clearsky = albuquerque.get_clearsky(three_days, model='simplified_solis')
@@ -305,8 +304,7 @@ def test_daily_insolation_limits_uneven(albuquerque):
     """daily_insolation_limits works with uneven timestamp spacing."""
     three_days = pd.date_range(
         start='1/1/2020',
-        end='1/4/2020',
-        closed='left',
+        end='1/3/2020 23:45',
         freq='15T'
     )
     clearsky = albuquerque.get_clearsky(three_days, model='simplified_solis')

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -2,7 +2,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 from pvanalytics.quality import outliers
 
 

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytz
 import pytest
 import pandas as pd
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 from pvanalytics.quality import time
 from ..conftest import requires_ruptures
 

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytz
 import pytest
 import pandas as pd
+import numpy as np
 from pandas.testing import assert_series_equal
 from pvanalytics.quality import time
 from ..conftest import requires_ruptures
@@ -195,7 +196,7 @@ def test_has_dst_no_dst_in_date_range(albuquerque):
 def midday(request, albuquerque):
     solar_position = albuquerque.get_solarposition(
         pd.date_range(
-            start='1/1/2020', end='3/1/2020', closed='left',
+            start='1/1/2020', end='2/29/2020 23:59',
             tz='MST', freq=request.param
         )
     )
@@ -207,7 +208,7 @@ def midday(request, albuquerque):
     )
     mid_day = mid_day.dt.hour * 60 + mid_day.dt.minute
     mid_day.index = pd.DatetimeIndex(mid_day.index, tz='MST')
-    return mid_day
+    return mid_day.astype(np.int64)
 
 
 @requires_ruptures

--- a/pvanalytics/tests/quality/test_util.py
+++ b/pvanalytics/tests/quality/test_util.py
@@ -1,6 +1,6 @@
 """Tests for utility functions."""
 import pandas as pd
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 import pytest
 from pvanalytics.quality import util
 

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -2,7 +2,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 from pvanalytics.quality import weather
 
 

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -12,9 +12,8 @@ def summer_times():
     """One hour time stamps from May 1 through September 30, 2020 in GMT+7"""
     return pd.date_range(
         start='2020-5-1',
-        end='2020-10-1',
+        end='2020-09-30 23:00',
         freq='H',
-        closed='left',
         tz='Etc/GMT+7'
     )
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
 numpy~=1.16.0
-pandas~=0.25.0
+pandas~=1.0.0
 pvlib~=0.9.4
 scipy~=1.4.0
 statsmodels~=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ TESTS_REQUIRE = [
 
 INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
-    'pandas >= 0.25.0, != 1.1.*',
+    'pandas >= 1.0.0, != 1.1.*',
     'pvlib >= 0.9.4',
     'scipy >= 1.4.0',
     'statsmodels >= 0.9.0',


### PR DESCRIPTION
- [x] Closes #168
~- [ ] Added tests to cover all new or modified code.~
~- [ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.~
~- [ ] Added new API functions to `docs/api.rst`.~
~- [ ] Non-API functions clearly documented with docstrings or comments as necessary.~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Various fixes in preparation for the upcoming release of pandas 2.0.0.  Mostly it comes down to using `pd.testing` instead of `pd.util.testing` and not using `closed` in `pd.date_range`, but the time has also come to fix #168. 