### PR TITLE
scipy 1.11 compatibility

### DIFF
--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -22,6 +22,7 @@ Bug Fixes
 * ``pvanalytics.__version__`` now correctly reports the version string instead
   of raising ``AttributeError``. (:pull:`181`)
 * Compatibility with pandas 2.0.0 (:pull:`185`)
+* Compatibility with scipy 1.11 (:pull:`196`)
 
 Requirements
 ~~~~~~~~~~~~

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -178,7 +178,7 @@ def shifts_ruptures(event_times, reference_times, period_min=2,
             duplicates='drop'
         )
     ).transform(
-        lambda shifted_period: stats.mode(shifted_period).mode[0]
+        lambda shifted_period: stats.mode(shifted_period, keepdims=False).mode
     )
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -2,7 +2,6 @@
 import warnings
 import pandas as pd
 import numpy as np
-from scipy import stats
 
 
 def spacing(times, freq):

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -178,7 +178,7 @@ def shifts_ruptures(event_times, reference_times, period_min=2,
             duplicates='drop'
         )
     ).transform(
-        lambda shifted_period: stats.mode(shifted_period, keepdims=False).mode
+        lambda shifted_period: shifted_period.mode().values[0]
     )
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)


### PR DESCRIPTION
- ~[ ] Closes #xxx~
- ~[ ] Added tests to cover all new or modified code.~
- ~[ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.~
- ~[ ] Added new API functions to `docs/api.rst`.~
- ~[ ] Non-API functions clearly documented with docstrings or comments as necessary.~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

The tests are failing in #186 due to unrelated changes in scipy (see the [1.11.0 release notes](http://scipy.github.io/devdocs/release/1.11.0-notes.html#expired-deprecations)):

> In [scipy.stats.mode](http://scipy.github.io/devdocs/reference/generated/scipy.stats.mode.html#scipy.stats.mode), the default value of keepdims is now False, and support for non-numeric input has been removed.

In this line of code, the `.mode(...).mode` is now returning a scalar, so trying to index with `[0]` fails:

https://github.com/pvlib/pvanalytics/blob/89d3c63d620280ef8c606afac116e76c074a173c/pvanalytics/quality/time.py#L181

This PR switches away from `scipy.stats.mode`, which has too inconsistent an interface across all versions to be easily used here, and instead just uses `pd.Series.mode`. 