### PR TITLE
Update the time shift Ruptures function with the new logic that was tested/validated at PVRW 2023

### DIFF
--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -11,6 +11,12 @@ Breaking Changes
   accounting for array incidence loss (IAM), and including losses in the PVWatts
   inverter model. Additionally, added optional arguments for bounding the azimuth range in
   during least squares optimization. (:issue:`147`, :pull:`180`)
+* Updated function :py:func:`~pvanalytics.quality.time.shifts_ruptures` to align with the
+  methodology tested and reported on at PVRW 2023 ("Survey of Time Shift Detection Algorithms
+  for Measured PV Data"). This includes converting the changepoint detection algorithm from
+  Pelt to Binary Segmentation (which runs much faster), and performing additional processing
+  to each detected segment to remove outliers and filter by a quantile cutoff instead of the
+  original rounding technique.
 
 
 Enhancements

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -16,7 +16,7 @@ Breaking Changes
   for Measured PV Data"). This includes converting the changepoint detection algorithm from
   Pelt to Binary Segmentation (which runs much faster), and performing additional processing
   to each detected segment to remove outliers and filter by a quantile cutoff instead of the
-  original rounding technique.
+  original rounding technique. (:pull:`197`)
 
 
 Enhancements

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -138,7 +138,7 @@ def shifts_ruptures(event_times, reference_times,
     # so the timezone is irrelevant.
     time_diff = \
         event_times.tz_localize(None) - reference_times.tz_localize(None)
-    break_points = ruptures.BinSeg(model='rbf',
+    break_points = ruptures.Binseg(model='rbf',
                                    min_size=period_min).fit_predict(
                                        signal=time_diff.values,
                                        pen=prediction_penalty

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -138,7 +138,7 @@ def shifts_ruptures(event_times, reference_times,
     # so the timezone is irrelevant. Get the time difference in minutes.
     time_diff = \
         (event_times.tz_localize(None) -
-         reference_times.tz_localize(None)).dt.total_seconds() / 60
+         reference_times.tz_localize(None))
     # Get the index before removing NaN's
     time_diff_orig_index = time_diff.index
     # # Remove any outliers that may skew the results

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -1,7 +1,6 @@
 """Quality tests related to time."""
 import warnings
 import pandas as pd
-import numpy as np
 from scipy import stats
 from pvanalytics.quality.outliers import zscore
 
@@ -122,7 +121,7 @@ def shifts_ruptures(event_times, reference_times,
     transit time in time of day.
 
     Derived from the PVFleets QA project.
-    
+
     References
     -------
     .. [1] Perry K., Meyers B., and Muller, M. "Survey of Time Shift
@@ -144,7 +143,7 @@ def shifts_ruptures(event_times, reference_times,
                                    min_size=period_min).fit_predict(
                                        signal=time_diff.values,
                                        pen=prediction_penalty
-                                       )
+    )
     # Make sure the entire series is covered by the intervals between
     # the breakpoints that were identified above. This means adding a
     # breakpoint at the beginning of the series (0) and at the end if
@@ -166,9 +165,9 @@ def shifts_ruptures(event_times, reference_times,
         segment = segment[~zscore(segment, zmax=zscore_cutoff,
                                   nan_policy='omit')]
         segment = segment[
-            (segment>=segment.quantile(bottom_quantile_threshold)) &
-            (segment<=segment.quantile(top_quantile_threshold))]
-        shift_amount.loc[idx_start: idx_end] = minute_rounding * \
+            (segment >= segment.quantile(bottom_quantile_threshold)) &
+            (segment <= segment.quantile(top_quantile_threshold))]
+        shift_amount.loc[index: index + 1] = minute_rounding * \
             round(float(segment.mean())/shift_min)
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -1,7 +1,6 @@
 """Quality tests related to time."""
 import warnings
 import pandas as pd
-from scipy import stats
 from pvanalytics.quality.outliers import zscore
 
 
@@ -167,7 +166,7 @@ def shifts_ruptures(event_times, reference_times,
         segment = segment[
             (segment >= segment.quantile(bottom_quantile_threshold)) &
             (segment <= segment.quantile(top_quantile_threshold))]
-        shift_amount.loc[index: index + 1] = minute_rounding * \
+        shift_amount.loc[index: index + 1] = shift_min * \
             round(float(segment.mean())/shift_min)
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -79,9 +79,19 @@ def shifts_ruptures(event_times, reference_times,
     prediction_penalty : int, default 13
         Penalty used in assessing change points.
         See :py:meth:`ruptures.detection.Pelt.predict` for more information.
-    zscore_cutoff=2,
-    bottom_quantile_threshold=.5,
-    top_quantile_threshold=1
+    zscore_cutoff : int, default 2
+        Z-score cutoff / maximum for filtering out outliers in each identified
+        segment found via changepount detection
+    bottom_quantile_threshold : float, default 0
+        Bottom quantile threshold for each time series segment identified via
+        changepoint detection. All data below this threshold is not considered
+        when determining the mean value for the segment, which is later
+        rounded to the nearest `period_min` value
+    top_quantile_threshold : float, default 0.5
+        Top quantile threshold for each time series segment identified via
+        changepoint detection. All data above this threshold is not considered
+        when determining the mean value for the segment, which is later
+        rounded to the nearest `period_min` value
 
     Returns
     -------
@@ -139,12 +149,6 @@ def shifts_ruptures(event_times, reference_times,
     time_diff = \
         (event_times.tz_localize(None) -
          reference_times.tz_localize(None))
-    # Get the index before removing NaN's
-    time_diff_orig_index = time_diff.index
-    # # Remove any outliers that may skew the results
-    # zscore_outlier_mask = zscore(time_diff, zmax=zscore_cutoff,
-    #                              nan_policy='omit')
-    # time_diff.loc[zscore_outlier_mask] = np.nan
     # Remove NaN's from the time_diff series, because NaN's screw up the
     # ruptures prediction
     time_diff = time_diff.dropna()

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -149,6 +149,8 @@ def shifts_ruptures(event_times, reference_times,
     time_diff = \
         (event_times.tz_localize(None) -
          reference_times.tz_localize(None))
+    # Get the index before removing NaN's
+    time_diff_orig_index = time_diff.index
     # Remove NaN's from the time_diff series, because NaN's screw up the
     # ruptures prediction
     time_diff = time_diff.dropna()
@@ -165,7 +167,7 @@ def shifts_ruptures(event_times, reference_times,
     break_points.insert(0, 0)
     if break_points[-1] != len(time_diff):
         break_points.append(len(time_diff))
-    # Go throguh each time shift segment and perform the following steps:
+    # Go through each time shift segment and perform the following steps:
     # 1) Remove the outliers from each segment using a z-score filter
     # 2) Remove any cases that are not within the bottom and top quantile
     #    parameters for the segment. This helps to remove more erroneous
@@ -183,7 +185,7 @@ def shifts_ruptures(event_times, reference_times,
             (segment <= segment.quantile(top_quantile_threshold))]
         shift_amount.iloc[break_points[index]: break_points[index + 1]] = \
             shift_min * round(float(segment.mean())/shift_min)
-    # Update the shift_amount series with the original time series
+    # Update the shift_amount series with the original time series index
     shift_amount = shift_amount.reindex(time_diff_orig_index).ffill()
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -78,7 +78,7 @@ def shifts_ruptures(event_times, reference_times,
         of `shift_min`. [minutes]
     prediction_penalty : int, default 13
         Penalty used in assessing change points.
-        See :py:meth:`ruptures.detection.Pelt.predict` for more information.
+        See :py:meth:`ruptures.detection.Binseg.predict` for more information.
     zscore_cutoff : int, default 2
         Z-score cutoff / maximum for filtering out outliers in each identified
         segment found via changepount detection

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -150,6 +150,7 @@ def shifts_ruptures(event_times, reference_times,
     time_diff = time_diff.dropna()
     # Run changepoint detection to find breaks
     break_points = ruptures.Binseg(model='rbf',
+                                   jump=1,
                                    min_size=period_min).fit_predict(
                                        signal=time_diff.values,
                                        pen=prediction_penalty)

--- a/pvanalytics/quality/time.py
+++ b/pvanalytics/quality/time.py
@@ -166,7 +166,7 @@ def shifts_ruptures(event_times, reference_times,
         segment = segment[
             (segment >= segment.quantile(bottom_quantile_threshold)) &
             (segment <= segment.quantile(top_quantile_threshold))]
-        shift_amount.loc[index: index + 1] = shift_min * \
+        shift_amount.iloc[index: index + 1] = shift_min * \
             round(float(segment.mean())/shift_min)
     # localize the shift_amount series to the timezone of the input
     shift_amount = shift_amount.tz_localize(event_times.index.tz)

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -485,26 +485,3 @@ def test_dst_dates(timezone, expected_dates):
         time.dst_dates(index.tz_localize(None), timezone),
         expected.tz_localize(None)
     )
-
-
-# def test_rounding():
-#     xs = pd.Series(
-#         [-10, 10, -16, 16, -28, 28, -30, 30, -8, 8, -7, 7, -3, 3, 0]
-#     )
-#     assert_series_equal(
-#         time._round_multiple(xs, 15),
-#         pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, -15, 15, 0, 0, 0, 0,
-#                     0])
-#     )
-#     assert_series_equal(
-#         time._round_multiple(xs, 15, up_from=9),
-#         pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-#     )
-#     assert_series_equal(
-#         time._round_multiple(xs, 15, up_from=15),
-#         pd.Series([0, 0, -15, 15, -15, 15, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-#     )
-#     assert_series_equal(
-#         time._round_multiple(xs, 30),
-#         pd.Series([0, 0, -30, 30, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-#     )

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -487,23 +487,24 @@ def test_dst_dates(timezone, expected_dates):
     )
 
 
-def test_rounding():
-    xs = pd.Series(
-        [-10, 10, -16, 16, -28, 28, -30, 30, -8, 8, -7, 7, -3, 3, 0]
-    )
-    assert_series_equal(
-        time._round_multiple(xs, 15),
-        pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, -15, 15, 0, 0, 0, 0, 0])
-    )
-    assert_series_equal(
-        time._round_multiple(xs, 15, up_from=9),
-        pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-    )
-    assert_series_equal(
-        time._round_multiple(xs, 15, up_from=15),
-        pd.Series([0, 0, -15, 15, -15, 15, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-    )
-    assert_series_equal(
-        time._round_multiple(xs, 30),
-        pd.Series([0, 0, -30, 30, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
-    )
+# def test_rounding():
+#     xs = pd.Series(
+#         [-10, 10, -16, 16, -28, 28, -30, 30, -8, 8, -7, 7, -3, 3, 0]
+#     )
+#     assert_series_equal(
+#         time._round_multiple(xs, 15),
+#         pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, -15, 15, 0, 0, 0, 0,
+#                     0])
+#     )
+#     assert_series_equal(
+#         time._round_multiple(xs, 15, up_from=9),
+#         pd.Series([-15, 15, -15, 15, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
+#     )
+#     assert_series_equal(
+#         time._round_multiple(xs, 15, up_from=15),
+#         pd.Series([0, 0, -15, 15, -15, 15, -30, 30, 0, 0, 0, 0, 0, 0, 0])
+#     )
+#     assert_series_equal(
+#         time._round_multiple(xs, 30),
+#         pd.Series([0, 0, -30, 30, -30, 30, -30, 30, 0, 0, 0, 0, 0, 0, 0])
+#     )


### PR DESCRIPTION
This update makes the changes to the original function so it now matches the finalized logic that I used for validation in the PVRW 2023 poster (https://www.nrel.gov/docs/fy23osti/85699.pdf). Most notably, we use binary segmentation instead of Pelt here, which results in a massive speedup while still being performant.

- [ ] Added tests to cover all new or modified code.
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.
- [x] Added new API functions to `docs/api.rst`.
- [x] Non-API functions clearly documented with docstrings or comments as necessary.
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue): -->
