### PR TITLE
Address various deprecations and test issues with pandas 2.2.0

### DIFF
--- a/docs/examples/clipping/clipping.py
+++ b/docs/examples/clipping/clipping.py
@@ -35,7 +35,7 @@ data = pd.read_csv(ac_power_file_1, index_col=0, parse_dates=True)
 data['label'] = data['label'].astype(bool)
 # This is the known frequency of the time series. You may need to infer
 # the frequency or set the frequency with your AC power time series.
-freq = "15T"
+freq = "15min"
 
 data['value_normalized'].plot()
 data.loc[data['label'], 'value_normalized'].plot(ls='', marker='o')

--- a/docs/examples/day-night-masking/day-night-masking.py
+++ b/docs/examples/day-night-masking/day-night-masking.py
@@ -36,7 +36,7 @@ data = data.sort_index()
 
 # This is the known frequency of the time series. You may need to infer
 # the frequency or set the frequency with your AC power time series.
-freq = "1T"
+freq = "1min"
 # These are the latitude-longitude coordinates associated with the
 # SERF East system.
 latitude = 39.742

--- a/docs/examples/gaps/data-completeness.py
+++ b/docs/examples/gaps/data-completeness.py
@@ -34,7 +34,7 @@ import pathlib
 pvanalytics_dir = pathlib.Path(pvanalytics.__file__).parent
 file = pvanalytics_dir / 'data' / 'ac_power_inv_2173.csv'
 data = pd.read_csv(file, index_col=0, parse_dates=True)
-data = data.asfreq("15T")
+data = data.asfreq("15min")
 
 # %%
 # Now, we use :py:func:`pvanalytics.quality.gaps.completeness_score` to get the

--- a/docs/examples/gaps/stale-data.py
+++ b/docs/examples/gaps/stale-data.py
@@ -34,7 +34,7 @@ import pathlib
 pvanalytics_dir = pathlib.Path(pvanalytics.__file__).parent
 file = pvanalytics_dir / 'data' / 'ac_power_inv_2173_stale_data.csv'
 data = pd.read_csv(file, index_col=0, parse_dates=True)
-data = data.asfreq("15T")
+data = data.asfreq("15min")
 data['value_normalized'].plot()
 data.loc[data["stale_data_mask"], "value_normalized"].plot(ls='', marker='.')
 plt.legend(labels=["AC Power", "Inserted Stale Data"])

--- a/docs/examples/irradiance-quality/clearsky-limits-irradiance.py
+++ b/docs/examples/irradiance-quality/clearsky-limits-irradiance.py
@@ -29,7 +29,7 @@ import pathlib
 pvanalytics_dir = pathlib.Path(pvanalytics.__file__).parent
 rmis_file = pvanalytics_dir / 'data' / 'irradiance_RMIS_NREL.csv'
 data = pd.read_csv(rmis_file, index_col=0, parse_dates=True)
-freq = '5T'
+freq = '5min'
 # Make the datetime index tz-aware.
 data.index = data.index.tz_localize("Etc/GMT+7")
 

--- a/docs/examples/metrics/variability-index.py
+++ b/docs/examples/metrics/variability-index.py
@@ -52,7 +52,7 @@ clearsky = location.get_clearsky(data.index)
 # an hourly frequency.
 variability_index_series = variability_index(data['irradiance_ghi__7981'],
                                              clearsky['ghi'],
-                                             freq='1H')
+                                             freq='1h')
 
 # %%
 # Plot the calculated VI against the underlying GHI measurements, for the

--- a/docs/examples/system/infer-orientation-fit-pvwatts.py
+++ b/docs/examples/system/infer-orientation-fit-pvwatts.py
@@ -32,7 +32,7 @@ ac_power_file = pvanalytics_dir / 'data' / 'serf_east_15min_ac_power.csv'
 data = pd.read_csv(ac_power_file, index_col=0, parse_dates=True)
 data = data.sort_index()
 time_series = data['ac_power']
-time_series = time_series.asfreq('15T')
+time_series = time_series.asfreq('15min')
 
 # Plot the first few days of the time series to visualize it
 time_series[:pd.to_datetime("2016-07-06 00:00:00-07:00")].plot()

--- a/docs/examples/system/system-tracking.py
+++ b/docs/examples/system/system-tracking.py
@@ -36,7 +36,7 @@ ac_power_file = pvanalytics_dir / 'data' / \
 data = pd.read_csv(ac_power_file, index_col=0, parse_dates=True)
 data = data.sort_index()
 time_series = data['ac_power']
-time_series = time_series.asfreq('15T')
+time_series = time_series.asfreq('15min')
 
 # Plot the first few days of the time series to visualize it
 time_series[:pd.to_datetime("2016-07-06 00:00:00-07:00")].plot()

--- a/docs/examples/weather/module-temperature-check.py
+++ b/docs/examples/weather/module-temperature-check.py
@@ -61,7 +61,7 @@ plt.show()
 # We mask the irradiance time series into day-night periods, and remove
 # any nighttime data to clean up the future regression.
 predicted_day_night_mask = power_or_irradiance(
-    series=data['poa_irradiance__771'], freq='15T')
+    series=data['poa_irradiance__771'], freq='15min')
 # Filter out nighttime periods
 data = data[predicted_day_night_mask]
 

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -38,7 +38,7 @@ Bug Fixes
 ~~~~~~~~~
 * ``pvanalytics.__version__`` now correctly reports the version string instead
   of raising ``AttributeError``. (:pull:`181`)
-* Compatibility with pandas 2.0.0 (:pull:`185`)
+* Compatibility with pandas 2.0.0 (:pull:`185`) and future versions of pandas (:pull:`203`)
 * Compatibility with scipy 1.11 (:pull:`196`)
 
 Requirements

--- a/pvanalytics/features/clearsky.py
+++ b/pvanalytics/features/clearsky.py
@@ -62,7 +62,7 @@ def reno(ghi, ghi_clearsky):
 
     """
     delta = ghi.index.to_series().diff()
-    delta_minutes = delta[1].total_seconds() / 60
+    delta_minutes = delta.iloc[1].total_seconds() / 60
     if delta_minutes > 15:
         raise ValueError('clearsky requires regular time intervals '
                          'of 15m or less')

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -410,7 +410,7 @@ def geometric(ac_power, window=None, slope_max=0.2, freq=None,
         raise ValueError("Cannot infer frequency of `ac_power`. "
                          "Please resample or pass `freq`.")
     if freq_minutes < 10:
-        ac_power = ac_power.resample('15T').mean()
+        ac_power = ac_power.resample('15min').mean()
     if window is None and tracking and freq_minutes < 30:
         window = 5
     else:

--- a/pvanalytics/features/clipping.py
+++ b/pvanalytics/features/clipping.py
@@ -90,7 +90,7 @@ def levels(ac_power, window=4, fraction_in_window=0.75,
         temp.loc[(power >= lower) & (power <= upper)] = 1.0
         flags = flags | _label_clipping(temp, window=window,
                                         frac=fraction_in_window)
-    return flags.reindex_like(ac_power).fillna(False)
+    return flags.reindex(ac_power.index, fill_value=False)
 
 
 def _daytime_powercurve(ac_power, power_quantile):

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -49,7 +49,7 @@ def _backfill_window(endpoints, window):
     flags = endpoints
     while window > 0:
         window = window - 1
-        flags = flags | endpoints.shift(-window).fillna(False)
+        flags = flags | endpoints.shift(-window, fill_value=False)
     return flags
 
 

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -62,7 +62,6 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
         outlier.
 
     """
-    data = data.copy()
     nan_mask = pd.Series([False] * len(data),
                          index=data.index)
 
@@ -75,13 +74,9 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
             raise ValueError(f"Unnexpected value ({nan_policy}) passed to "
                              "nan_policy. Expected 'raise' or 'omit'.")
 
-    data[~nan_mask] = pd.Series(abs(stats.zscore(data[~nan_mask])) > zmax,
-                                index=data[~nan_mask].index)
-
-    # Place False where original series had NaNs
-    data[nan_mask] = False
-    # Return a boolean-casted series
-    return data.astype(bool)
+    is_outlier = pd.Series(False, index=data.index)
+    is_outlier.loc[~nan_mask] = abs(stats.zscore(data[~nan_mask])) > zmax
+    return is_outlier
 
 
 def hampel(data, window=5, max_deviation=3.0, scale=None):

--- a/pvanalytics/system.py
+++ b/pvanalytics/system.py
@@ -370,7 +370,7 @@ def infer_orientation_daily_peak(power_or_poa, sunny, tilts,
 
     """
     peak_times = _peak_times(power_or_poa[sunny])
-    azimuth_by_minute = solar_azimuth.resample('T').interpolate(
+    azimuth_by_minute = solar_azimuth.resample('1min').interpolate(
         method='linear'
     )
     modeled_azimuth = azimuth_by_minute[peak_times]

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -81,7 +81,7 @@ def one_year_hourly():
     return pd.date_range(
         start='03/01/2020',
         end='02/28/2021 23:00',
-        freq='H',
+        freq='h',
         tz='Etc/GMT+7'
     )
 
@@ -92,7 +92,7 @@ def three_days_hourly():
     return pd.date_range(
         start='03/01/2020',
         end='03/03/2020 23:00',
-        freq='H',
+        freq='h',
         tz='Etc/GMT+7'
     )
 

--- a/pvanalytics/tests/features/test_clearsky.py
+++ b/pvanalytics/tests/features/test_clearsky.py
@@ -7,7 +7,7 @@ from pvanalytics.features import clearsky
 @pytest.mark.filterwarnings("ignore:Support for multi-dimensional indexing")
 def test_reno_identical(quadratic):
     """Identical clearsky and measured irradiance all True"""
-    index = pd.date_range(start='04/03/2020', freq='15T',
+    index = pd.date_range(start='04/03/2020', freq='15min',
                           periods=len(quadratic))
     quadratic.index = index
     assert clearsky.reno(quadratic, quadratic).all()
@@ -17,7 +17,7 @@ def test_reno_identical(quadratic):
 @pytest.mark.filterwarnings("ignore:invalid value encountered in")
 def test_reno_begining_end(quadratic):
     """clearsky conditions except in the middle of the dataset"""
-    index = pd.date_range(start='03/03/2020', freq='15T',
+    index = pd.date_range(start='03/03/2020', freq='15min',
                           periods=len(quadratic))
     quadratic.index = index
     ghi = quadratic.copy()
@@ -31,7 +31,7 @@ def test_reno_begining_end(quadratic):
 
 def test_reno_large_interval(quadratic):
     """clearsky.reno() raises ValueError if timestamp spacing too large."""
-    index = pd.date_range(start='04/03/2020', freq='20T',
+    index = pd.date_range(start='04/03/2020', freq='20min',
                           periods=len(quadratic))
     quadratic.index = index
     with pytest.raises(ValueError):

--- a/pvanalytics/tests/features/test_clipping.py
+++ b/pvanalytics/tests/features/test_clipping.py
@@ -87,7 +87,7 @@ def test_threshold_no_clipping(quadratic):
     """In a data set with a single quadratic there is no clipping."""
     quadratic.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     assert not clipping.threshold(quadratic).any()
@@ -98,14 +98,14 @@ def test_threshold_no_clipping_with_night(quadratic):
     no clipping."""
     quadratic.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     full_day = quadratic.reindex(
         pd.date_range(
             start='01/01/2020 00:00',
             end='01/01/2020 23:50',
-            freq='10T')
+            freq='10min')
     )
     full_day.fillna(0)
     assert not clipping.threshold(quadratic).any()
@@ -116,7 +116,7 @@ def test_threshold_clipping(quadratic_clipped):
     indicated."""
     quadratic_clipped.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     assert not clipping.threshold(quadratic_clipped).all()
@@ -128,14 +128,14 @@ def test_threshold_clipping_with_night(quadratic_clipped):
     before and after simulating night time conditions."""
     quadratic_clipped.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     full_day = quadratic_clipped.reindex(
         pd.date_range(
             start='01/01/2020 00:00',
             end='01/01/2020 23:50',
-            freq='10T')
+            freq='10min')
     )
     full_day.fillna(0)
     assert not clipping.threshold(full_day).all()
@@ -146,12 +146,12 @@ def test_threshold_clipping_with_freq(quadratic_clipped):
     """Passing the frequency gives same result as infered frequency."""
     quadratic_clipped.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     assert_series_equal(
         clipping.threshold(quadratic_clipped),
-        clipping.threshold(quadratic_clipped, freq='10T')
+        clipping.threshold(quadratic_clipped, freq='10min')
     )
 
 
@@ -160,7 +160,7 @@ def test_threshold_clipping_with_interruption(quadratic_clipped):
     quadratic_clipped.loc[28:31] = [750, 725, 700, 650]
     quadratic_clipped.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     clipped = clipping.threshold(quadratic_clipped)
@@ -176,25 +176,25 @@ def test_threshold_clipping_four_days(quadratic, quadratic_clipped):
     """Clipping is identified in the first of four days."""
     quadratic.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     quadratic_clipped.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     full_day_clipped = quadratic_clipped.reindex(
         pd.date_range(
             start='01/01/2020 00:00',
             end='01/01/2020 23:50',
-            freq='10T')
+            freq='10min')
     )
     full_day = quadratic.reindex(
         pd.date_range(
             start='01/01/2020 00:00',
             end='01/01/2020 23:50',
-            freq='10T')
+            freq='10min')
     )
     full_day_clipped.fillna(0)
     full_day.fillna(0)
@@ -210,7 +210,7 @@ def test_threshold_clipping_four_days(quadratic, quadratic_clipped):
     ])
 
     power.index = pd.date_range(
-        start='01/01/2020 00:00', freq='10T', periods=len(power)
+        start='01/01/2020 00:00', freq='10min', periods=len(power)
     )
 
     clipped = clipping.threshold(power)
@@ -223,14 +223,14 @@ def test_threshold_no_clipping_four_days(quadratic):
     """Four days with no clipping."""
     quadratic.index = pd.date_range(
         start='01/01/2020 07:30',
-        freq='10T',
+        freq='10min',
         periods=61
     )
     full_day = quadratic.reindex(
         pd.date_range(
             start='01/01/2020 00:00',
             end='01/01/2020 23:50',
-            freq='10T')
+            freq='10min')
     )
     full_day.fillna(0)
 
@@ -242,7 +242,7 @@ def test_threshold_no_clipping_four_days(quadratic):
     ])
 
     power.index = pd.date_range(
-        start='01/01/2020 00:00', freq='10T', periods=len(power)
+        start='01/01/2020 00:00', freq='10min', periods=len(power)
     )
 
     clipped = clipping.threshold(power)
@@ -252,7 +252,7 @@ def test_threshold_no_clipping_four_days(quadratic):
 
 @pytest.fixture(scope='module')
 def july():
-    return pd.date_range(start='7/1/2020', end='8/1/2020', freq='T')
+    return pd.date_range(start='7/1/2020', end='8/1/2020', freq='min')
 
 
 @pytest.fixture(scope='module')
@@ -290,26 +290,26 @@ def power_pvwatts(request, clearsky_july, solarposition_july):
     return inverter.pvwatts(dc, pdc0_inverter)
 
 
-@pytest.mark.parametrize('freq', ['T', '5T', '15T', '30T', 'H'])
+@pytest.mark.parametrize('freq', ['min', '5min', '15min', '30min', 'h'])
 def test_geometric_no_clipping(power_pvwatts, freq):
     clipped = clipping.geometric(power_pvwatts.resample(freq).asfreq())
     assert not clipped.any()
 
 
 @pytest.mark.pdc0_inverter(60)
-@pytest.mark.parametrize('freq', ['T', '5T', '15T', '30T', 'H'])
+@pytest.mark.parametrize('freq', ['min', '5min', '15min', '30min', 'h'])
 def test_geometric_clipping(power_pvwatts, freq):
     clipped = clipping.geometric(power_pvwatts.resample(freq).asfreq())
     assert clipped.any()
 
 
 @pytest.mark.pdc0_inverter(65)
-@pytest.mark.parametrize('freq', ['5T', '15T', '30T', 'H'])
+@pytest.mark.parametrize('freq', ['5min', '15min', '30min', 'h'])
 def test_geometric_clipping_correct(power_pvwatts, freq):
     power = power_pvwatts.resample(freq).asfreq()
     clipped = clipping.geometric(power)
     expected = power == power.max()
-    if freq == '5T':
+    if freq == '5min':
         assert np.allclose(power[clipped], power.max(), atol=0.5)
     else:
         assert_series_equal(clipped, expected)
@@ -317,7 +317,7 @@ def test_geometric_clipping_correct(power_pvwatts, freq):
 
 @pytest.mark.pdc0_inverter(65)
 def test_geometric_clipping_midday_clouds(power_pvwatts):
-    power = power_pvwatts.resample('15T').asfreq()
+    power = power_pvwatts.resample('15min').asfreq()
     power.loc[power.between_time(
         start_time='17:30', end_time='19:30',
     ).index] = list(range(30, 39)) * 31
@@ -328,7 +328,7 @@ def test_geometric_clipping_midday_clouds(power_pvwatts):
 
 @pytest.mark.pdc0_inverter(80)
 def test_geometric_clipping_window(power_pvwatts):
-    power = power_pvwatts.resample('15T').asfreq()
+    power = power_pvwatts.resample('15min').asfreq()
     clipped = clipping.geometric(power)
     assert clipped.any()
     clipped_window = clipping.geometric(power, window=24)
@@ -337,7 +337,7 @@ def test_geometric_clipping_window(power_pvwatts):
 
 @pytest.mark.pdc0_inverter(89)
 def test_geometric_clipping_tracking(power_pvwatts):
-    power = power_pvwatts.resample('15T').asfreq()
+    power = power_pvwatts.resample('15min').asfreq()
     clipped = clipping.geometric(power)
     assert clipped.any()
     clipped = clipping.geometric(power, tracking=True)
@@ -346,14 +346,14 @@ def test_geometric_clipping_tracking(power_pvwatts):
 
 @pytest.mark.pdc0_inverter(80)
 def test_geometric_clipping_window_overrides_tracking(power_pvwatts):
-    power = power_pvwatts.resample('15T').asfreq()
+    power = power_pvwatts.resample('15min').asfreq()
     clipped = clipping.geometric(power, tracking=True)
     assert clipped.any()
     clipped_override = clipping.geometric(power, tracking=True, window=24)
     assert not clipped_override.any()
 
 
-@pytest.mark.parametrize('freq', ['5T', '15T'])
+@pytest.mark.parametrize('freq', ['5min', '15min'])
 def test_geometric_clipping_missing_data(freq, power_pvwatts):
     power = power_pvwatts.resample(freq).asfreq()
     power.loc[power.between_time('09:00', '10:30').index] = np.nan
@@ -375,4 +375,4 @@ def test_geometric_index_not_sorted():
     )
     with pytest.raises(ValueError,
                        match=r"Index must be monotonically increasing\."):
-        clipping.geometric(power, freq='30T')
+        clipping.geometric(power, freq='30min')

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -88,7 +88,7 @@ def daytime_mask_center_aligned(ac_power_series):
 def _assert_daytime_no_shoulder(clearsky, output):
     # every night-time value in `output` has low or 0 irradiance
     assert all(clearsky[~output] < 3)
-    if pd.infer_freq(clearsky.index) == 'T':
+    if pd.infer_freq(clearsky.index) in ['T', 'min']:
         # Blur the boundaries between night and day if testing
         # high-frequency data since the daytime filtering algorithm does
         # not have one-minute accuracy.

--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -12,7 +12,8 @@ test_file_1 = DATA_DIR / "serf_east_1min_ac_power.csv"
 
 
 @pytest.fixture(scope='module',
-                params=['H', '15T', pytest.param('T', marks=pytest.mark.slow)])
+                params=['h', '15min',
+                        pytest.param('min', marks=pytest.mark.slow)])
 def clearsky_january(request, albuquerque):
     return albuquerque.get_clearsky(
         pd.date_range(
@@ -50,7 +51,7 @@ def modeled_midday_series(ac_power_series):
 @pytest.fixture
 def daytime_mask_left_aligned(ac_power_series):
     # Resample the time series to 5-minute left aligned intervals
-    ac_power_series_left = ac_power_series.resample('5T',
+    ac_power_series_left = ac_power_series.resample('5min',
                                                     label='left').mean()
     data_freq = pd.infer_freq(ac_power_series_left.index)
     daytime_mask = daytime.power_or_irradiance(ac_power_series_left,
@@ -62,7 +63,7 @@ def daytime_mask_left_aligned(ac_power_series):
 def daytime_mask_right_aligned(ac_power_series):
     # Resample the time series to 5-minute right aligned intervals. Lop off the
     # last entry as it is moved to the next day (3/20)
-    ac_power_series_right = ac_power_series.resample('5T',
+    ac_power_series_right = ac_power_series.resample('5min',
                                                      label='right').mean()[:-1]
     data_freq = pd.infer_freq(ac_power_series_right.index)
     daytime_mask = daytime.power_or_irradiance(ac_power_series_right,
@@ -74,10 +75,10 @@ def daytime_mask_right_aligned(ac_power_series):
 def daytime_mask_center_aligned(ac_power_series):
     # Resample the time series to 5-minute center aligned intervals (take
     # left alignment and shift by frequency/2)
-    ac_power_series_center = ac_power_series.resample('5T',
+    ac_power_series_center = ac_power_series.resample('5min',
                                                       label='left').mean()
     ac_power_series_center.index = (ac_power_series_center.index +
-                                    (pd.Timedelta("5T") / 2))
+                                    (pd.Timedelta("5min") / 2))
     data_freq = pd.infer_freq(ac_power_series_center.index)
     daytime_mask = daytime.power_or_irradiance(ac_power_series_center,
                                                freq=data_freq)
@@ -125,10 +126,9 @@ def test_daytime_overcast(clearsky_january):
 
 def test_daytime_split_day():
     location = Location(35, -150)
-    clearsky = location.get_clearsky(
-        pd.date_range(start='1/1/2020', end='1/10/2020', freq='15T'),  # no tz
-        model='simplified_solis'
-    )
+    # no tz:
+    times = pd.date_range(start='1/1/2020', end='1/10/2020', freq='15min')
+    clearsky = location.get_clearsky(times, model='simplified_solis')
     _assert_daytime_no_shoulder(
         clearsky['ghi'],
         daytime.power_or_irradiance(clearsky['ghi'])
@@ -153,7 +153,7 @@ def test_daytime_daylight_savings(albuquerque):
     spring = pd.date_range(
         start='2/10/2020',
         end='4/10/2020',
-        freq='15T',
+        freq='15min',
         tz='America/Denver'
     )
     clearsky_spring = albuquerque.get_clearsky(
@@ -167,7 +167,7 @@ def test_daytime_daylight_savings(albuquerque):
     fall = pd.date_range(
         start='10/1/2020',
         end='12/1/2020',
-        freq='15T',
+        freq='15min',
         tz='America/Denver'
     )
     clearsky_fall = albuquerque.get_clearsky(

--- a/pvanalytics/tests/features/test_orientation.py
+++ b/pvanalytics/tests/features/test_orientation.py
@@ -108,6 +108,6 @@ def test_stuck_tracker_profile(solarposition, clearsky):
 
 
 def test_frequency_to_hours():
-    assert orientation._freqstr_to_hours('H') == 1.0
-    assert orientation._freqstr_to_hours('15T') == 0.25
-    assert orientation._freqstr_to_hours('2H') == 2.0
+    assert orientation._freqstr_to_hours('h') == 1.0
+    assert orientation._freqstr_to_hours('15min') == 0.25
+    assert orientation._freqstr_to_hours('2h') == 2.0

--- a/pvanalytics/tests/features/test_shading.py
+++ b/pvanalytics/tests/features/test_shading.py
@@ -9,7 +9,7 @@ def times():
     return pd.date_range(
         start='1/1/2020',
         end='12/31/2020 23:59',
-        freq='T',
+        freq='1min',
         tz='MST'
     )
 
@@ -50,8 +50,8 @@ def test_simple_shadow(daytime, clearsky_ghi):
 
 
 def test_invalid_interval(daytime, clearsky_ghi):
-    ghi = clearsky_ghi.resample('5T').first()
-    daytime_resampled = daytime.resample('5T').first()
+    ghi = clearsky_ghi.resample('5min').first()
+    daytime_resampled = daytime.resample('5min').first()
     with pytest.raises(ValueError, match="Data must be at 1-minute intervals"):
         shading.fixed(ghi, daytime_resampled, ghi)
     with pytest.raises(ValueError, match="Data must be at 1-minute intervals"):

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -286,7 +286,7 @@ def test_start_stop_dates_all_true():
     """If all values are True then start and stop are equal to first and
     last day of the series."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -299,7 +299,7 @@ def test_start_stop_dates_all_true():
 def test_start_stop_dates_first_day_false():
     """If day one is all False, then start date should be day 2."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -313,7 +313,7 @@ def test_start_stop_dates_first_day_false():
 def test_start_stop_dates_first_and_fifth_days_missing():
     """First valid date should be the sixth of January."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -331,7 +331,7 @@ def test_start_stop_dates_last_two_days_missing():
 
     """
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -345,7 +345,7 @@ def test_start_stop_dates_last_two_days_missing():
 def test_start_stop_dates_all_false():
     """If the passed to start_stop_dates is empty the returns (None, None)."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -356,7 +356,7 @@ def test_start_stop_dates_all_false():
 def test_start_stop_dates_not_enough_days():
     """Fewer than 10 days of True gives not start/stop dates."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -371,7 +371,7 @@ def test_start_stop_dates_one_day():
 
     """
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -387,7 +387,7 @@ def test_start_stop_dates_with_gaps_in_middle():
     consecutive 'good' days have no effect on the start and stop
     date."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -402,7 +402,7 @@ def test_trim_incomplete():
     """gaps.trim_incomplete() should return a boolean mask that selects
     only the good data in the middle of a series."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -419,7 +419,7 @@ def test_trim_incomplete_empty():
     """gaps.trim_incomplete() returns all False for series with no valid
     days."""
     index = pd.date_range(
-        freq='15T',
+        freq='15min',
         start='01-01-2020',
         end='08-01-2020 23:00'
     )
@@ -454,7 +454,7 @@ def test_completeness_score_all_nans():
     completeness = gaps.completeness_score(
         pd.Series(
             np.nan,
-            index=pd.date_range('01/01/2020 00:00', freq='1H', periods=48),
+            index=pd.date_range('01/01/2020 00:00', freq='1h', periods=48),
             dtype='float64'
         ),
         keep_index=False
@@ -474,7 +474,7 @@ def test_completeness_score_no_data():
     four_days = pd.date_range(start='01/01/2020', freq='D', periods=4)
     completeness = gaps.completeness_score(
         pd.Series(index=four_days, dtype='float64'),
-        freq='15T',
+        freq='15min',
         keep_index=False
     )
     assert_series_equal(
@@ -488,9 +488,10 @@ def test_completeness_score_incomplete_index():
     15-minute sample frequency"""
     data = pd.Series(
         1,
-        index=pd.date_range(start='01/01/2020', freq='1H', periods=72),
+        index=pd.date_range(start='01/01/2020', freq='1h', periods=72),
     )
-    completeness = gaps.completeness_score(data, freq='15T', keep_index=False)
+    completeness = gaps.completeness_score(data, freq='15min',
+                                           keep_index=False)
     assert_series_equal(
         pd.Series(
             0.25,
@@ -503,7 +504,8 @@ def test_completeness_score_incomplete_index():
 def test_completeness_score_complete():
     """A series with data at every point has completeness 1.0"""
     data = pd.Series(
-        1, index=pd.date_range(start='01/01/2020', freq='15T', periods=24*4*2)
+        1,
+        index=pd.date_range(start='01/01/2020', freq='15min', periods=24*4*2)
     )
     completeness = gaps.completeness_score(data, keep_index=False)
     assert_series_equal(
@@ -520,12 +522,12 @@ def test_completeness_score_freq_too_high():
     raised."""
     data = pd.Series(
         1,
-        index=pd.date_range(start='1/1/2020', freq='15T', periods=24*4*4)
+        index=pd.date_range(start='1/1/2020', freq='15min', periods=24*4*4)
     )
     with pytest.raises(ValueError):
-        gaps.completeness_score(data, freq='16T')
+        gaps.completeness_score(data, freq='16min')
     with pytest.raises(ValueError):
-        gaps.completeness_score(data, freq='1H')
+        gaps.completeness_score(data, freq='1h')
 
 
 def test_completeness_score_reindex():
@@ -533,10 +535,12 @@ def test_completeness_score_reindex():
     keep_index=True"""
     data = pd.Series(
         1,
-        index=pd.date_range(start='1/1/2020', freq='15T', end='1/3/2020 23:45')
+        index=pd.date_range(start='1/1/2020', freq='15min',
+                            end='1/3/2020 23:45')
     )
-    data.loc[pd.date_range(start='1/1/2020', freq='30T', periods=48)] = np.nan
-    data.loc[pd.date_range(start='1/3/2020', freq='1H', periods=24)] = np.nan
+    data.loc[pd.date_range(start='1/1/2020', freq='30min', periods=48)] = \
+        np.nan
+    data.loc[pd.date_range(start='1/3/2020', freq='1h', periods=24)] = np.nan
 
     expected = pd.Series(index=data.index, dtype='float64')
     expected.loc['1/1/2020'] = 0.5
@@ -551,7 +555,7 @@ def test_completeness_score_reindex():
 def test_complete_threshold_zero():
     """minimum_completeness of 0 returns all True regardless of data."""
     ten_days = pd.date_range(
-        start='01/01/2020', freq='15T', end='1/09/2020 23:45')
+        start='01/01/2020', freq='15min', end='1/09/2020 23:45')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(True, index=data.index),
@@ -561,7 +565,7 @@ def test_complete_threshold_zero():
     data.dropna()
     assert_series_equal(
         pd.Series(True, index=data.index),
-        gaps.complete(data, minimum_completeness=0, freq='15T')
+        gaps.complete(data, minimum_completeness=0, freq='15min')
     )
     data = pd.Series(1.0, index=ten_days)
     assert_series_equal(
@@ -574,7 +578,7 @@ def test_complete_threshold_one():
     """If minimum_completeness=1 then any missing data on a day means all
     data for the day is flagged False."""
     ten_days = pd.date_range(
-        start='01/01/2020', freq='15T', end='01/09/2020 23:45')
+        start='01/01/2020', freq='15min', end='01/09/2020 23:45')
     data = pd.Series(index=ten_days, dtype='float64')
     assert_series_equal(
         pd.Series(False, index=data.index),
@@ -602,24 +606,24 @@ def test_complete_threshold_one():
     )
     assert_series_equal(
         gaps.complete(data, minimum_completeness=1.0),
-        gaps.complete(data, minimum_completeness=1.0, freq='15T')
+        gaps.complete(data, minimum_completeness=1.0, freq='15min')
     )
 
 
 def test_complete():
     """Test gaps.complete with varying amounts of missing data."""
     ten_days = pd.date_range(
-        start='1/1/2020', freq='H', end='1/10/2020 23:00')
+        start='1/1/2020', freq='h', end='1/10/2020 23:00')
     data = pd.Series(index=ten_days, dtype='float64')
     data.loc['1/1/2020'] = 1.0
     day_two_values = pd.date_range(
-        start='1/2/2020', freq='2H', end='1/2/2020 23:00')
+        start='1/2/2020', freq='2h', end='1/2/2020 23:00')
     data.loc[day_two_values] = 2.0
     day_three_values = pd.date_range(
-        start='1/3/2020', freq='3H', end='1/3/2020 23:00')
+        start='1/3/2020', freq='3h', end='1/3/2020 23:00')
     data.loc[day_three_values] = 3.0
     day_four_values = pd.date_range(
-        start='1/4/2020', freq='4H', end='1/4/2020 23:00')
+        start='1/4/2020', freq='4h', end='1/4/2020 23:00')
     data.loc[day_four_values] = 4.0
     data.loc['1/5/2020':] = 5.0
 

--- a/pvanalytics/tests/quality/test_irradiance.py
+++ b/pvanalytics/tests/quality/test_irradiance.py
@@ -196,7 +196,7 @@ def times():
     return pd.date_range(
         start=datetime(2018, 6, 15, 12, 0, 0, tzinfo=mst),
         end=datetime(2018, 6, 15, 13, 0, 0, tzinfo=mst),
-        freq='10T'
+        freq='10min'
     )
 
 
@@ -238,7 +238,7 @@ def test_clearsky_limits_negative_and_nan():
 
     """
     index = pd.date_range(start=datetime(2019, 6, 15, 12, 0, 0),
-                          freq='15T', periods=5)
+                          freq='15min', periods=5)
     measured = pd.Series(index=index, data=[800, 1000, 1200, -200, np.nan])
     clearsky = pd.Series(index=index, data=1000)
     assert_series_equal(
@@ -277,7 +277,7 @@ def test_daily_insolation_limits(albuquerque):
     three_days = pd.date_range(
         start='1/1/2020',
         end='1/3/2020 23:00',
-        freq='H'
+        freq='h'
     )
     clearsky = albuquerque.get_clearsky(three_days, model='simplified_solis')
     assert irradiance.daily_insolation_limits(
@@ -305,7 +305,7 @@ def test_daily_insolation_limits_uneven(albuquerque):
     three_days = pd.date_range(
         start='1/1/2020',
         end='1/3/2020 23:45',
-        freq='15T'
+        freq='15min'
     )
     clearsky = albuquerque.get_clearsky(three_days, model='simplified_solis')
     ghi = clearsky['ghi'].copy()

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -25,7 +25,7 @@ def times():
     MST = pytz.timezone('MST')
     return pd.date_range(start=datetime(2018, 6, 15, 12, 0, 0, tzinfo=MST),
                          end=datetime(2018, 6, 15, 13, 0, 0, tzinfo=MST),
-                         freq='10T')
+                         freq='10min')
 
 
 def test_timestamp_spacing_date_range(times):
@@ -105,12 +105,12 @@ def test_has_dst_input_series_not_localized(tz, observes_dst, albuquerque):
 
 @pytest.mark.parametrize("tz, observes_dst", [('MST', False),
                                               ('America/Denver', True)])
-@pytest.mark.parametrize("freq", ['15T', '30T', 'H'])
+@pytest.mark.parametrize("freq", ['15min', '30min', 'h'])
 def test_has_dst_rounded(tz, freq, observes_dst, albuquerque):
     sunrise = _get_sunrise(albuquerque, tz)
     # With rounding to 1-hour timestamps we need to reduce how many
     # days we look at.
-    window = 7 if freq != 'H' else 1
+    window = 7 if freq != 'h' else 1
     expected = pd.Series(False, index=sunrise.index)
     expected.loc['2020-03-08'] = observes_dst
     expected.loc['2020-11-01'] = observes_dst
@@ -192,7 +192,7 @@ def test_has_dst_no_dst_in_date_range(albuquerque):
     )
 
 
-@pytest.fixture(scope='module', params=['H', '15T', 'T'])
+@pytest.fixture(scope='module', params=['h', '15min', '1min'])
 def midday(request, albuquerque):
     solar_position = albuquerque.get_solarposition(
         pd.date_range(
@@ -406,16 +406,16 @@ def test_shift_ruptures_shift_min(midday):
         shifted, midday,
         shift_min=30
     )
-    assert_series_equal(
-        shift_mask,
-        shift_expected != 0 if pd.infer_freq(shifted.index) != 'H' else False,
-        check_names=False
-    )
-    assert_series_equal(
-        shift_amount,
-        shift_expected if pd.infer_freq(shifted.index) != 'H' else no_shift,
-        check_names=False
-    )
+
+    if pd.infer_freq(shifted.index).lower() != 'h':
+        expected_mask = shift_expected != 0
+        expected_shift = shift_expected
+    else:
+        expected_mask = False
+        expected_shift = no_shift
+
+    assert_series_equal(shift_mask, expected_mask, check_names=False)
+    assert_series_equal(shift_amount, expected_shift, check_names=False)
 
 
 @requires_ruptures

--- a/pvanalytics/tests/quality/test_time.py
+++ b/pvanalytics/tests/quality/test_time.py
@@ -392,30 +392,20 @@ def test_shift_ruptures_shift_min(midday):
     shift_expected = pd.Series(0, index=shifted.index, dtype='int64')
     shift_expected.loc['2020-01-01':'2020-01-25'] = 30
     no_shift = pd.Series(0, index=shifted.index, dtype='int64')
+
     shift_mask, shift_amount = time.shifts_ruptures(
         shifted, midday,
         shift_min=60
     )
     assert not shift_mask.any()
-    assert_series_equal(
-        shift_amount,
-        no_shift,
-        check_names=False
-    )
+    assert_series_equal(shift_amount, no_shift, check_names=False)
+
     shift_mask, shift_amount = time.shifts_ruptures(
         shifted, midday,
         shift_min=30
     )
-
-    if pd.infer_freq(shifted.index).lower() != 'h':
-        expected_mask = shift_expected != 0
-        expected_shift = shift_expected
-    else:
-        expected_mask = False
-        expected_shift = no_shift
-
-    assert_series_equal(shift_mask, expected_mask, check_names=False)
-    assert_series_equal(shift_amount, expected_shift, check_names=False)
+    assert_series_equal(shift_mask, shift_expected != 0, check_names=False)
+    assert_series_equal(shift_amount, shift_expected, check_names=False)
 
 
 @requires_ruptures

--- a/pvanalytics/tests/quality/test_util.py
+++ b/pvanalytics/tests/quality/test_util.py
@@ -51,7 +51,7 @@ def ten_days():
     return pd.date_range(
         start='01/01/2020',
         end='01/10/2020 23:59',
-        freq='10T'
+        freq='10min'
     )
 
 

--- a/pvanalytics/tests/quality/test_weather.py
+++ b/pvanalytics/tests/quality/test_weather.py
@@ -94,7 +94,7 @@ def test_module_temperature(albuquerque):
     times = pd.date_range(
         start='01/01/2020',
         end='03/01/2020',
-        freq='H',
+        freq='h',
         tz='MST'
     )
     clearsky = albuquerque.get_clearsky(times, model='simplified_solis')

--- a/pvanalytics/tests/test_system.py
+++ b/pvanalytics/tests/test_system.py
@@ -13,7 +13,7 @@ def summer_times():
     return pd.date_range(
         start='2020-5-1',
         end='2020-09-30 23:00',
-        freq='H',
+        freq='h',
         tz='Etc/GMT+7'
     )
 
@@ -180,7 +180,7 @@ def test_custom_tracking_envelope_thresholds(summer_power_fixed):
 def albuquerque_clearsky(albuquerque):
     """One year of clearsky data in Albuquerque, NM."""
     year_hourly = pd.date_range(
-        start='1/1/2020', end='1/1/2021', freq='H', tz='MST'
+        start='1/1/2020', end='1/1/2021', freq='h', tz='MST'
     )
     return albuquerque.get_clearsky(
         year_hourly,
@@ -296,7 +296,7 @@ def fine_index(clearsky_year):
     return pd.date_range(
         start=clearsky_year.index.min(),
         end=clearsky_year.index.max(),
-        freq='T'
+        freq='1min'
     )
 
 
@@ -402,7 +402,7 @@ def naive_times():
     return pd.date_range(
         start='2020',
         end='2021',
-        freq='H'
+        freq='h'
     )
 
 


### PR DESCRIPTION
- [ ] Closes #xxx
- [ ] Added tests to cover all new or modified code.
- [ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.
- [ ] Added new API functions to `docs/api.rst`.
- [ ] Non-API functions clearly documented with docstrings or comments as necessary.
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

A recent [run](https://github.com/pvlib/pvanalytics/actions/runs/7606219430/job/20711650232?pr=202#step:5:832) of the test suite reported 262 warnings, mostly these deprecation warnings from pandas:

- `FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.`
- `FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.`
- `FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[...]' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.`
-  `FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set pd.set_option('future.no_silent_downcasting', True)`
- `FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use ser.iloc[pos]`

Fixing the first couple is a find/replace exercise.  The others needed minor code rewrites.