### PR TITLE
Add Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         requirements: ['']
         include:
           - requirements: "-r requirements-min.txt"

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -1,7 +1,7 @@
 .. _whatsnew_020:
 
-0.2.0 (anticipated December 2023)
------------------------------
+0.2.0 (anticipated February 2024)
+---------------------------------
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
@@ -55,7 +55,7 @@ Documentation
 
 Testing
 ~~~~~~~
-* Added testing for python 3.11. (:pull:`189`)
+* Added testing for python 3.11 and 3.12. (:pull:`189`, :pull:`204`)
 
 
 Contributors

--- a/pvanalytics/tests/conftest.py
+++ b/pvanalytics/tests/conftest.py
@@ -6,7 +6,8 @@ import pvlib
 from pvlib import location, pvsystem
 from pvlib.temperature import TEMPERATURE_MODEL_PARAMETERS
 from pathlib import Path
-from pkg_resources import Requirement, parse_version
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 TEST_DIR = Path(__file__).parent
 DATA_DIR = TEST_DIR.parent / 'data'
@@ -46,8 +47,7 @@ def requires_pvlib(versionspec, reason=''):
     reason : str, optional
         Additional context to show in pytest log output
     """
-    req = Requirement.parse('pvlib' + versionspec)
-    is_satisfied = parse_version(pvlib.__version__) in req
+    is_satisfied = Version(pvlib.__version__) in SpecifierSet(versionspec)
     message = 'requires pvlib' + versionspec
     if reason:
         message += f'({reason})'

--- a/pvanalytics/tests/test_pvanalytics.py
+++ b/pvanalytics/tests/test_pvanalytics.py
@@ -1,5 +1,5 @@
 
-from pkg_resources import parse_version
+from packaging.version import Version
 import pvanalytics
 
 
@@ -7,5 +7,5 @@ def test___version__():
     # check that the version string is determined correctly.
     # if the version string is messed up for some reason, it should be
     # '0+unknown', which is not greater than '0.0.1'.
-    version = parse_version(pvanalytics.__version__)
-    assert version > parse_version('0.0.1')
+    version = Version(pvanalytics.__version__)
+    assert version > Version('0.0.1')

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ URL = 'https://github.com/pvlib/pvanalytics'
 TESTS_REQUIRE = [
     'pytest',
     'pytest-cov',
+    'packaging',
 ]
 
 INSTALL_REQUIRES = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
You are free to strikethrough any checklist items that do not apply or to add additional items that are not on this list. -->

- ~[ ] Closes #xxx~
- ~[ ] Added tests to cover all new or modified code.~
- ~[ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.~
- ~[ ] Added new API functions to `docs/api.rst`.~
- ~[ ] Non-API functions clearly documented with docstrings or comments as necessary.~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Keeping as draft for now, to see if the 3.12 jobs work smoothly. 
