### PR TITLE
Advance minimum scipy to 1.6

### DIFF
--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -44,7 +44,7 @@ Bug Fixes
 Requirements
 ~~~~~~~~~~~~
 * Advance minimum ``pvlib`` to 0.9.4, ``numpy`` to 0.16.0,
-  ``pandas`` to 1.0.0, and ``scipy`` to 1.4.0. (:pull:`179`, :pull:`185`)
+  ``pandas`` to 1.0.0, and ``scipy`` to 1.6.0. (:pull:`179`, :pull:`185`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvanalytics/quality/irradiance.py
+++ b/pvanalytics/quality/irradiance.py
@@ -417,7 +417,7 @@ def _daily_total(series):
     if freq:
         freq_hours = _to_hours(freq)
         return series.resample('D').apply(
-            integrate.trapz,
+            integrate.trapezoid,
             dx=freq_hours
         )
     hours = pd.Series(
@@ -425,7 +425,7 @@ def _daily_total(series):
         index=series.index
     )
     return series.resample('D').apply(
-        lambda day: integrate.trapz(y=day, x=hours[day.index])
+        lambda day: integrate.trapezoid(y=day, x=hours[day.index])
     )
 
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 numpy~=1.16.0
 pandas~=1.0.0
 pvlib~=0.9.4
-scipy~=1.4.0
+scipy~=1.6.0
 statsmodels~=0.9.0
 scikit-image~=0.16.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ INSTALL_REQUIRES = [
     'numpy >= 1.16.0',
     'pandas >= 1.0.0, != 1.1.*',
     'pvlib >= 0.9.4',
-    'scipy >= 1.4.0',
+    'scipy >= 1.6.0',
     'statsmodels >= 0.9.0',
     'scikit-image >= 0.16.0',
     'importlib-metadata; python_version < "3.8"',


### PR DESCRIPTION
- ~[ ] Closes #xxx~
- ~[ ] Added tests to cover all new or modified code.~
- ~[ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.~
- ~[ ] Added new API functions to `docs/api.rst`.~
- ~[ ] Non-API functions clearly documented with docstrings or comments as necessary.~
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Recent CI runs show a deprecation warning from scipy: `scipy.integrate.trapz` is deprecated and replaced by `scipy.integrate.trapezoid`:

```
pvanalytics/tests/quality/test_irradiance.py: 24 warnings
  /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/pandas/core/resample.py:450: DeprecationWarning: 'scipy.integrate.trapz' is deprecated in favour of 'scipy.integrate.trapezoid' and will be removed in SciPy 1.14.0
    func = lambda x: how(x, *args, **kwargs)

pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
pvanalytics/tests/quality/test_irradiance.py::test_daily_insolation_limits_uneven
  /home/runner/work/pvanalytics/pvanalytics/pvanalytics/quality/irradiance.py:428: DeprecationWarning: 'scipy.integrate.trapz' is deprecated in favour of 'scipy.integrate.trapezoid' and will be removed in SciPy 1.14.0
    lambda day: integrate.trapz(y=day, x=hours[day.index])
```

We could work around the name change with `try/except`, but it's easiest to just increase our minimum scipy so that `trapezoid` is always available.  Note that scipy 1.6.0 was released [December 31, 2020](https://pypi.org/project/scipy/1.6.0).