### PR TITLE
Allow tz-aware timstamps in `gaps.trim`

### DIFF
--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -40,7 +40,8 @@ Bug Fixes
   of raising ``AttributeError``. (:pull:`181`)
 * Compatibility with pandas 2.0.0 (:pull:`185`)
 * Compatibility with scipy 1.11 (:pull:`196`)
-* Fixed pandas version with gaps function
+* Updated function :py:func:`~pvanalytics.quality.gaps.trim` to handle pandas 2.0.0 update for tz-aware timeseries
+ (:pull:`206`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -63,3 +64,4 @@ Contributors
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Abhishek Parikh (:ghuser:`abhisheksparikh`)
+* Quyen Nguyen (:ghuser:`qnguyen345`)

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -40,6 +40,7 @@ Bug Fixes
   of raising ``AttributeError``. (:pull:`181`)
 * Compatibility with pandas 2.0.0 (:pull:`185`)
 * Compatibility with scipy 1.11 (:pull:`196`)
+* Fixed pandas version with gaps function
 
 Requirements
 ~~~~~~~~~~~~

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -409,9 +409,11 @@ def trim(series, days=10):
     """
     start, end = start_stop_dates(series, days=days)
     mask = pd.Series(False, index=series.index)
-    
+
     if start:
-        mask.loc[pd.to_datetime(start.date()).tz_localize(series.index.tz):pd.to_datetime(end.date()).tz_localize(series.index.tz)] = True
+        mask.loc[pd.to_datetime(start.date()).tz_localize(series.index.tz):
+                 pd.to_datetime(end.date()).tz_localize(series.index.tz)] = \
+            True
     return mask
 
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -408,12 +408,10 @@ def trim(series, days=10):
 
     """
     start, end = start_stop_dates(series, days=days)
-    mask = pd.Series(False, index=series.index.tz_convert(None))
+    mask = pd.Series(False, index=series.index)
     
     if start:
-        start = pd.to_datetime(start.tz_convert(None))
-        end = pd.to_datetime(end.tz_convert(None))
-        mask.loc[start.date():end.date()] = True
+        mask.loc[pd.to_datetime(start.date()).tz_localize(series.index.tz):pd.to_datetime(end.date()).tz_localize(series.index.tz)] = True
     return mask
 
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -411,9 +411,7 @@ def trim(series, days=10):
     mask = pd.Series(False, index=series.index)
 
     if start:
-        mask.loc[pd.to_datetime(start.date()).tz_localize(series.index.tz):
-                 pd.to_datetime(end.date()).tz_localize(series.index.tz)] = \
-            True
+        mask.loc[start:end] = True
     return mask
 
 

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -408,8 +408,11 @@ def trim(series, days=10):
 
     """
     start, end = start_stop_dates(series, days=days)
-    mask = pd.Series(False, index=series.index)
+    mask = pd.Series(False, index=series.index.tz_convert(None))
+    
     if start:
+        start = pd.to_datetime(start.tz_convert(None))
+        end = pd.to_datetime(end.tz_convert(None))
         mask.loc[start.date():end.date()] = True
     return mask
 

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -447,11 +447,12 @@ def test_trim_daily_index():
         expected,
         gaps.trim(data)
     )
-    
+
+
 def test_trim_daily_index_tz_aware():
     """trim works when data has a daily index and data is tz-aware."""
     data = pd.Series(True, index=pd.date_range(
-        start='1/1/2020', end='2/29/2020', freq='D', tz = "Etc/GMT+8"))
+        start='1/1/2020', end='2/29/2020', freq='D', tz="Etc/GMT+8"))
     assert gaps.trim(data).all()
     data.iloc[0:8] = False
     data.iloc[9] = False

--- a/pvanalytics/tests/quality/test_gaps.py
+++ b/pvanalytics/tests/quality/test_gaps.py
@@ -447,6 +447,26 @@ def test_trim_daily_index():
         expected,
         gaps.trim(data)
     )
+    
+def test_trim_daily_index_tz_aware():
+    """trim works when data has a daily index and data is tz-aware."""
+    data = pd.Series(True, index=pd.date_range(
+        start='1/1/2020', end='2/29/2020', freq='D', tz = "Etc/GMT+8"))
+    assert gaps.trim(data).all()
+    data.iloc[0:8] = False
+    data.iloc[9] = False
+    expected = data.copy()
+    expected.iloc[0:10] = False
+    assert_series_equal(
+        expected,
+        gaps.trim(data)
+    )
+    data.iloc[-5:] = False
+    expected.iloc[-5:] = False
+    assert_series_equal(
+        expected,
+        gaps.trim(data)
+    )
 
 
 def test_completeness_score_all_nans():


### PR DESCRIPTION
Updated quality.gaps.trim function for updated versions of Pandas 2.0
<!-- Thank you for your contribution! Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
You are free to strikethrough any checklist items that do not apply or to add additional items that are not on this list. -->

- [ ] Closes #xxx
- [x] Added tests to cover all new or modified code.
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.
- [x] Added new API functions to `docs/api.rst`.
- [x] Non-API functions clearly documented with docstrings or comments as necessary.
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue): -->
