### PR TITLE
Drop python 3.7; fix Mac OS CI jobs

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         requirements: ['']
         include:
           - requirements: "-r requirements-min.txt"
-            python-version: 3.7
+            python-version: 3.8
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/docs/whatsnew/0.2.1.rst
+++ b/docs/whatsnew/0.2.1.rst
@@ -1,0 +1,30 @@
+.. _whatsnew_021:
+
+0.2.1 (not yet released)
+------------------------
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Bug Fixes
+~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+* Minimum python advanced to 3.8. (:pull:`210`)
+* Minimum statsmodels advanced to 0.10.0 and numpy to 1.17.0. (:pull:`210`)
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+
+Contributors
+~~~~~~~~~~~~

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,5 +2,5 @@ numpy~=1.16.0
 pandas~=1.0.0
 pvlib~=0.9.4
 scipy~=1.6.0
-statsmodels~=0.9.0
+statsmodels~=0.10.0
 scikit-image~=0.16.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,4 +1,4 @@
-numpy~=1.16.0
+numpy~=1.17.0
 pandas~=1.0.0
 pvlib~=0.9.4
 scipy~=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ TESTS_REQUIRE = [
 ]
 
 INSTALL_REQUIRES = [
-    'numpy >= 1.16.0',
+    'numpy >= 1.17.0',
     'pandas >= 1.0.0, != 1.1.*',
     'pvlib >= 0.9.4',
     'scipy >= 1.6.0',
-    'statsmodels >= 0.9.0',
+    'statsmodels >= 0.10.0',
     'scikit-image >= 0.16.0',
     'importlib-metadata; python_version < "3.8"',
 ]


### PR DESCRIPTION
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Recent Mac OS CI jobs are failing.  I think updating the version of `setup-python` we're using will fix those, with the exception of python 3.7, which is no longer supported, so this PR drops py 3.7 here as well.
