### PR TITLE
`test_daytime.py`: work around pvlib v0.11.1 sunrise/set issue

### DIFF
--- a/pvanalytics/tests/features/test_daytime.py
+++ b/pvanalytics/tests/features/test_daytime.py
@@ -38,13 +38,13 @@ def ac_power_series():
 @pytest.fixture
 def modeled_midday_series(ac_power_series):
     # Get the modeled sunrise and sunset for the location
+    dates = ac_power_series.index.normalize().unique()
     modeled_sunrise_sunset_df = pvlib.solarposition.sun_rise_set_transit_spa(
-        ac_power_series.index, 39.742, -105.1727)
-    modeled_sunrise_sunset_df.index = modeled_sunrise_sunset_df.index.date
-    modeled_sunrise_sunset_df = modeled_sunrise_sunset_df.drop_duplicates()
+        dates, 39.742, -105.1727)
     # Take the 'transit' column as the midday point between sunrise and
     # sunset for each day in the modeled irradiance series
     modeled_midday_series = modeled_sunrise_sunset_df['transit']
+    modeled_midday_series.index = dates.date
     return modeled_midday_series
 
 


### PR DESCRIPTION
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

`test_daytime.py::test_consistent_modeled_midday_series` is failing with pvlib 0.11.1 due to https://github.com/pvlib/pvlib-python/issues/2238

The pvlib issue affected this pvanalytics test through coincidental implementation detail. This PR works around the change so that the pvanalytics test works with both the previous and the current pvlib behavior. 