### PR TITLE
Fix issue with `window_length` in `reno` clearsky detection

### DIFF
--- a/docs/whatsnew/v0.2.3.rst
+++ b/docs/whatsnew/v0.2.3.rst
@@ -10,7 +10,8 @@ Enhancements
 
 Bug Fixes
 ~~~~~~~~~
-
+* :py:func:`pvanalytics.features.clearsky.reno` now correctly passes
+  ``window_length`` to the underlying pvlib function. (:pull:`221`)
 
 Requirements
 ~~~~~~~~~~~~

--- a/pvanalytics/features/clearsky.py
+++ b/pvanalytics/features/clearsky.py
@@ -72,7 +72,7 @@ def reno(ghi, ghi_clearsky):
         ghi,
         ghi_clearsky,
         ghi.index,
-        window_length,
+        window_length=window_length,
         lower_line_length=-5*scale_factor,
         upper_line_length=10*scale_factor,
         slope_dev=8*scale_factor


### PR DESCRIPTION
- [ ] Closes #xxx
- [ ] Added tests to cover all new or modified code.
- [ ] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.
- [ ] Added new API functions to `docs/api.rst`.
- [ ] Non-API functions clearly documented with docstrings or comments as necessary.
- [ ] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [ ] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

`reno` was accidentally passing `window_length` to the `infer_limits` parameter.  That means the window length was not being provided to the underlying pvlib function and instead the default was used.  It also means that, since non-zero numbers are truthy, presumably this function has effectively had `infer_limits=True`.

@cwhanse should `infer_limits=True` be retained here?