### PR TITLE
Drop python 3.9

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         requirements: ['']
         include:
           - requirements: "-r requirements-min.txt"
-            python-version: 3.9
+            python-version: "3.10"
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Finish Coveralls Upload
         run: |
           pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     runs-on: ubuntu-latest
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/whatsnew/v0.2.3.rst
+++ b/docs/whatsnew/v0.2.3.rst
@@ -15,12 +15,13 @@ Bug Fixes
 
 Requirements
 ~~~~~~~~~~~~
-* Advance minimum python to 3.8, and the following dependencies (:pull:`220`):
+* Advance minimum python to 3.10, and the following dependencies (:pull:`220`, :pull:`228`):
 
-  - numpy: 1.20.0
-  - pandas: 1.3.0
-  - statsmodels: 0.13.0
-  - scikit-image: 0.18.0
+  - numpy: 1.21.2
+  - pandas: 1.3.3
+  - scipy: 1.7.2
+  - statsmodels: 0.13.1
+  - scikit-image: 0.19.0
 
 
 Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ description = "PVAnalytics is a python library for the analysis of photovoltaic 
 authors = [
     { name = "pvanalytics Contributors", email = "pvlib-admin@googlegroups.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
-    'numpy >= 1.20.0',
-    'pandas >= 1.3.0',
+    'numpy >= 1.21.2',
+    'pandas >= 1.3.3',
     'pvlib >= 0.9.4',
-    'scipy >= 1.6.0',
-    'statsmodels >= 0.13.0',
-    'scikit-image >= 0.18.0',
+    'scipy >= 1.7.2',
+    'statsmodels >= 0.13.1',
+    'scikit-image >= 0.19.0',
 ]
 license = "MIT"
 classifiers = [

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
-numpy~=1.20.0
-pandas~=1.3.0
-pvlib~=0.9.4
-scipy~=1.6.0
-statsmodels~=0.13.0
-scikit-image~=0.18.0
+numpy==1.21.2
+pandas===1.3.3
+pvlib==0.9.4
+scipy==1.7.2
+statsmodels==0.13.1
+scikit-image==0.19.0


### PR DESCRIPTION
Python 3.9 reaches end-of-life in October 2025: https://devguide.python.org/versions/