### PR TITLE
Add compare_reference and quantile_threshold to pvanalytics.quality.outliers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -132,6 +132,8 @@ Functions for detecting outliers.
    quality.outliers.tukey
    quality.outliers.zscore
    quality.outliers.hampel
+   quality.outliers.compare_reference
+   quality.outliers.quantile_threshold
 
 Time
 ----

--- a/docs/whatsnew/v0.2.3.rst
+++ b/docs/whatsnew/v0.2.3.rst
@@ -7,6 +7,12 @@
 Enhancements
 ~~~~~~~~~~~~
 
+* :py:func:`pvanalytics.quality.outliers.compare_reference` added for detecting
+  outliers based on deviations from a reference signal. (:issue:`224`, :pull:``)
+
+* :py:func:`pvanalytics.quality.outliers.quantile_threshold` added for
+  estimating threshold curves using quantile regression. (:issue:`224`, :pull:``)
+
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/whatsnew/v0.2.3.rst
+++ b/docs/whatsnew/v0.2.3.rst
@@ -8,10 +8,10 @@ Enhancements
 ~~~~~~~~~~~~
 
 * :py:func:`pvanalytics.quality.outliers.compare_reference` added for detecting
-  outliers based on deviations from a reference signal. (:issue:`224`, :pull:``)
+  outliers based on deviations from a reference signal. (:issue:`224`, :pull:`232`)
 
 * :py:func:`pvanalytics.quality.outliers.quantile_threshold` added for
-  estimating threshold curves using quantile regression. (:issue:`224`, :pull:``)
+  estimating threshold curves using quantile regression. (:issue:`224`, :pull:`232`)
 
 
 Bug Fixes

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -1,7 +1,9 @@
 """Functions for identifying and labeling outliers."""
 import pandas as pd
+import numpy as np
 from scipy import stats
 from statsmodels import robust
+
 
 
 def tukey(data, k=1.5):
@@ -124,3 +126,89 @@ def hampel(data, window=5, max_deviation=3.0, scale=None):
         kwargs=kwargs
     )
     return deviation > max_deviation * mad
+
+
+def compare_reference(actual, reference, comparison='difference',
+                      method='zscore', **kwargs):
+    """Identify outliers in `actual` based on deviations from `reference`.
+
+    The `actual` and `reference` series are compared using the
+    specified `comparison` type. The resulting deviations are then
+    checked for outliers using `method`.
+
+    Parameters
+    ----------
+    actual : Series
+        The data in which to find outliers.
+    reference : Series
+        The reference data to compare against.
+    comparison : {'difference', 'relative', 'absolute_difference'}, \
+        default 'difference'
+        How to compare `actual` and `reference`.
+        If 'difference', then `actual - reference`.
+        If 'relative', then `(actual - reference) / reference`.
+        If 'absolute_difference', then `abs(actual - reference)`.
+    method : {'zscore', 'tukey'}, default 'zscore'
+        The method used to identify outliers in the deviations.
+    **kwargs
+        Passed to the outlier detection `method` (e.g. `zmax` for
+        `zscore` or `k` for `tukey`).
+
+    Returns
+    -------
+    Series
+        A series of booleans with True for each value in `actual`
+        that is an outlier.
+
+    """
+    if comparison == 'difference':
+        deviations = actual - reference
+    elif comparison == 'relative':
+        deviations = (actual - reference) / reference
+    elif comparison == 'absolute_difference':
+        deviations = abs(actual - reference)
+    else:
+        raise ValueError(f"Invalid comparison '{comparison}'. "
+                         "Expected 'difference', 'relative', or "
+                         "'absolute_difference'.")
+
+    if method == 'zscore':
+        return zscore(deviations, **kwargs)
+    elif method == 'tukey':
+        return tukey(deviations, **kwargs)
+    else:
+        raise ValueError(f"Invalid method '{method}'. "
+                         "Expected 'zscore' or 'tukey'.")
+
+
+def quantile_threshold(x, y, quantile, formula='y ~ x'):
+    """Estimate a threshold curve using quantile regression.
+
+    This function uses quantile regression to find a threshold curve
+    for the data in `y` as a function of `x`.
+
+    Parameters
+    ----------
+    x : array_like
+        The independent variable.
+    y : Series
+        The dependent variable.
+    quantile : float
+        The quantile to estimate (between 0 and 1).
+    formula : str, default 'y ~ x'
+        The model formula passed to `statsmodels.formula.api.quantreg`.
+        The data frame passed to statsmodels will have columns named 'x'
+        and 'y'.
+
+    Returns
+    -------
+    Series
+        The predicted threshold values at each point in `x`.
+
+    """
+    import statsmodels.formula.api as smf
+    data = pd.DataFrame({'x': x, 'y': y})
+    model = smf.quantreg(formula, data)
+    res = model.fit(q=quantile)
+    return res.predict(data)
+

--- a/pvanalytics/tests/quality/test_outliers.py
+++ b/pvanalytics/tests/quality/test_outliers.py
@@ -168,4 +168,88 @@ def test_hampel_scale():
     data.iloc[20] = -25
     data.iloc[40] = 15
     data.iloc[60] = 5
-    assert not all(outliers.hampel(data) == outliers.hampel(data, scale=0.1))
+    assert not (outliers.hampel(data) == outliers.hampel(data, scale=0.1)).all()
+
+
+def test_compare_reference_difference():
+    """compare_reference identifies outliers in the difference."""
+    actual = pd.Series([1.0, 2.0, 3.0, 4.0, 10.0])
+    reference = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    # deviations: [0, 0, 0, 0, 5]
+    # z-scores: [-0.5, -0.5, -0.5, -0.5, 2.0]
+    expected = pd.Series([False, False, False, False, True])
+    assert_series_equal(
+        outliers.compare_reference(
+            actual, reference,
+            comparison='difference',
+            method='zscore',
+            zmax=1.5
+        ),
+        expected
+    )
+
+
+def test_compare_reference_relative():
+    """compare_reference identifies outliers in the relative difference."""
+    actual = pd.Series([1.0, 2.0, 3.0, 4.0, 8.0])
+    reference = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    # deviations: [0, 0, 0, 0, 0.6]
+    # z-scores: [-0.5, -0.5, -0.5, -0.5, 2.0]
+    expected = pd.Series([False, False, False, False, True])
+    assert_series_equal(
+        outliers.compare_reference(
+            actual, reference,
+            comparison='relative',
+            method='zscore',
+            zmax=1.5
+        ),
+        expected
+    )
+
+
+def test_compare_reference_absolute_difference():
+    """compare_reference identifies outliers in the absolute difference."""
+    actual = pd.Series([1.0, 2.0, 3.0, 4.0, 0.0])
+    reference = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    # deviations: [0, 0, 0, 0, 5]
+    expected = pd.Series([False, False, False, False, True])
+    assert_series_equal(
+        outliers.compare_reference(
+            actual, reference,
+            comparison='absolute_difference',
+            method='zscore',
+            zmax=1.5
+        ),
+        expected
+    )
+
+
+def test_compare_reference_tukey():
+    """compare_reference works with tukey method."""
+    actual = pd.Series([1.0, 2.0, 3.0, 4.0, 20.0])
+    reference = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    # deviations: [0, 0, 0, 0, 15]
+    expected = pd.Series([False, False, False, False, True])
+    assert_series_equal(
+        outliers.compare_reference(
+            actual, reference,
+            method='tukey'
+        ),
+        expected
+    )
+
+
+def test_quantile_threshold():
+    """quantile_threshold returns expected values."""
+    x = np.arange(100)
+    # y = 2x + 10 + noise
+    np.random.seed(1234)
+    y = 2 * x + 10 + np.random.normal(0, 1, 100)
+    threshold = outliers.quantile_threshold(x, pd.Series(y), 0.9)
+    assert len(threshold) == 100
+    # For a large enough sample, the slope should be close to 2
+    # and intercept close to 10 + 1.28*1
+    # We just check if it's generally in the right ballpark
+    assert np.all(threshold > 2 * x)
+    assert np.all(threshold < 2 * x + 20)
+


### PR DESCRIPTION
## Description

Adds two new outlier detection functions to `pvanalytics.quality.outliers`:

- `compare_reference` : detects outliers based on deviations from a reference signal
- `quantile_threshold` : estimates threshold curves using quantile regression

Closes #224

---

- [x] Closes #224
- [x] Added tests to cover all new or modified code.
- [x] Clearly documented all new API functions with [PEP257](https://www.python.org/dev/peps/pep-0257/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings.
- [x] Added new API functions to `docs/api.rst`.
- [x] Non-API functions clearly documented with docstrings or comments as necessary.
- [x] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.