### PR TITLE
shading: use morphology.footprint_rectangle((1, 3)) for 1x3 structuring element

### DIFF
--- a/pvanalytics/features/shading.py
+++ b/pvanalytics/features/shading.py
@@ -7,6 +7,7 @@ import pvlib
 from pvanalytics import util
 from skimage.morphology import rectangle as footprint_rectangle
 
+
 def _to_image(data, width):
     """Convert data to an image.
 

--- a/pvanalytics/features/shading.py
+++ b/pvanalytics/features/shading.py
@@ -5,7 +5,8 @@ from scipy import ndimage
 from skimage import morphology, measure
 import pvlib
 from pvanalytics import util
-
+from skimage.morphology import footprint_rectangle
+from skimage.morphology import rectangle as footprint_rectangle
 
 def _to_image(data, width):
     """Convert data to an image.
@@ -365,7 +366,7 @@ def fixed(ghi, daytime, clearsky, interval=None, min_gradient=2):
     threshold = gradient > min_gradient  # binary image of wire candidates
 
     # From here we CAN use skimage because we are working with binary images.
-    three_minute_mask = morphology.footprint_rectangle((1, 3))
+    three_minute_mask = footprint_rectangle(1, 3)
     wires = morphology.remove_small_objects(
         morphology.binary_closing(threshold, three_minute_mask),
         min_size=200,

--- a/pvanalytics/features/shading.py
+++ b/pvanalytics/features/shading.py
@@ -365,7 +365,7 @@ def fixed(ghi, daytime, clearsky, interval=None, min_gradient=2):
     threshold = gradient > min_gradient  # binary image of wire candidates
 
     # From here we CAN use skimage because we are working with binary images.
-    three_minute_mask = morphology.rectangle(1, 3)
+    three_minute_mask = morphology.footprint_rectangle((1, 3))
     wires = morphology.remove_small_objects(
         morphology.binary_closing(threshold, three_minute_mask),
         min_size=200,

--- a/pvanalytics/features/shading.py
+++ b/pvanalytics/features/shading.py
@@ -5,7 +5,6 @@ from scipy import ndimage
 from skimage import morphology, measure
 import pvlib
 from pvanalytics import util
-from skimage.morphology import footprint_rectangle
 from skimage.morphology import rectangle as footprint_rectangle
 
 def _to_image(data, width):

--- a/pvanalytics/features/shading.py
+++ b/pvanalytics/features/shading.py
@@ -113,7 +113,7 @@ def _prepare_images(ghi, clearsky, daytime, interval):
     ghi_image = pd.DataFrame(cloudless_image).interpolate(
         axis=0,
         limit_direction='both'
-    ).to_numpy()
+    ).to_numpy().copy()
     # set night to nan
     ghi_image[~_to_image(daytime.to_numpy(), image_width)] = np.nan
     return (

--- a/pvanalytics/quality/gaps.py
+++ b/pvanalytics/quality/gaps.py
@@ -274,7 +274,7 @@ def completeness_score(series, keep_index=True):
         (fraction of the day for which `series` has data).
 
     """
-    seconds_per_sample = series.index.diff().total_seconds()[1]
+    seconds_per_sample = (series.index[1] - series.index[0]).total_seconds()
     daily_counts = series.resample('D').count()
     daily_completeness = (daily_counts * seconds_per_sample) / (1440*60)
     if keep_index:


### PR DESCRIPTION
Fixes a TypeError / FutureWarning caused by differing scikit-image APIs. The structuring element creation in pvanalytics/features/shading.py now uses the modern `morphology.footprint_rectangle((1,3))` call.

**Testing** 
<img width="1542" height="761" alt="image" src="https://github.com/user-attachments/assets/0f7e4f5f-b0a4-44f7-a7ea-73e03177754c" />
<img width="1542" height="101" alt="image" src="https://github.com/user-attachments/assets/95da46ff-e454-4a93-a1a2-3b78b90e002e" />

<!-- Thank you for your contribution! Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
You are free to strikethrough any checklist items that do not apply or to add additional items that are not on this list. -->

- [x] Closes #226
- [x] Non-API functions clearly documented with docstrings or comments as necessary.
- [ ] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue): -->
