### PR TITLE
BUG: fix divide by zero in quartic_restricted when y is constant

### DIFF
--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -127,8 +127,7 @@ def quartic_restricted_r2(x, y, noon=720):
     )
     model = _quartic(x, params[0], params[1], params[2], params[3])
     residuals = y - model
-    ss_res = np.sum(residuals**2)
     ss_tot = np.sum((y - np.mean(y))**2)
     if ss_tot == 0:
-        return 0.0  
-    return 1 - (ss_res / ss_tot)
+        return 0.0
+    return 1 - (np.sum(residuals**2) / ss_tot)

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -127,4 +127,8 @@ def quartic_restricted_r2(x, y, noon=720):
     )
     model = _quartic(x, params[0], params[1], params[2], params[3])
     residuals = y - model
-    return 1 - (np.sum(residuals**2) / np.sum((y - np.mean(y))**2))
+    ss_res = np.sum(residuals**2)
+    ss_tot = np.sum((y - np.mean(y))**2)
+    if ss_tot == 0:
+        return 0.0  
+    return 1 - (ss_res / ss_tot)

--- a/pvanalytics/util/_functions.py
+++ b/pvanalytics/util/_functions.py
@@ -14,11 +14,5 @@ def freq_to_timedelta(freq):
     -------
     Timedelta
         Timedelta corresponding to a single period at `freq`.
-        For offsets that cannot be directly converted (e.g. 'D', 'W'),
-        falls back to using the offset's nanosecond representation.
     """
-    offset = frequencies.to_offset(freq)
-    try:
-        return pd.to_timedelta(offset)
-    except ValueError:
-        return pd.Timedelta(offset.nanos, unit='ns')
+    return pd.to_timedelta(frequencies.to_offset(freq))

--- a/pvanalytics/util/_functions.py
+++ b/pvanalytics/util/_functions.py
@@ -14,5 +14,11 @@ def freq_to_timedelta(freq):
     -------
     Timedelta
         Timedelta corresponding to a single period at `freq`.
+        For offsets that cannot be directly converted (e.g. 'D', 'W'),
+        falls back to using the offset's nanosecond representation.
     """
-    return pd.to_timedelta(frequencies.to_offset(freq))
+    offset = frequencies.to_offset(freq)
+    try:
+        return pd.to_timedelta(offset)
+    except ValueError:
+        return pd.Timedelta(offset.nanos, unit='ns')


### PR DESCRIPTION
## Description
`pvanalytics/util/_fit.py` raised `RuntimeWarning: divide by zero encountered in scalar divide` when `y` contains constant values.

In `quartic_restricted`, the R² denominator `np.sum((y - np.mean(y))**2)` evaluates to zero when all values in `y` are identical. This caused a `RuntimeWarning` in:
- `test_orientation.py::test_ghi_not_tracking`
- `test_orientation.py::test_power_tracking_perturbed`

**Fix:** Check if `ss_tot == 0` before dividing. If so, return `0.0` since R² is undefined for constant data (no variation to explain).

<!-- Thank you for your contribution! Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
You are free to strikethrough any checklist items that do not apply or to add additional items that are not on this list. -->
- [x] Closes #234 
- [x] Pull request is nearly complete and ready for detailed review.
- [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue): -->
