### PR TITLE
BUG: suppress RuntimeWarning in snow.categorize and outliers.zscore

### DIFF
--- a/docs/whatsnew/v0.2.3.rst
+++ b/docs/whatsnew/v0.2.3.rst
@@ -15,6 +15,10 @@ Bug Fixes
 * Remove freq parameter from :py:func:`pvanalytics.quality.gaps.completeness`
   and :py:func:`pvanalytics.quality.gaps.completeness_score`. Frequency is now
   always calculated from the input data's DatetimeIndex. (:pull:`236`) 
+* Suppress divide-by-zero warnings in
+  :mod:`pvanalytics.features.snow` and precision-loss warnings in
+  :mod:`pvanalytics.quality.outliers` by extending ``np.errstate`` to
+include ``invalid='ignore'``. (:issue:`#237`, :pull:`YYY`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -39,3 +43,4 @@ Testing
 Contributors
 ~~~~~~~~~~~~
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Omesh Chandure (:ghuser: `Omesh37`)

--- a/pvanalytics/features/snow.py
+++ b/pvanalytics/features/snow.py
@@ -224,7 +224,7 @@ def categorize(transmission, measured_voltage,
     modeled_voltage_with_snow_copy = np.where(
         transmission == 0, 0, modeled_voltage_with_snow)
 
-    with np.errstate(divide='ignore',invalid='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         vmp_ratio =\
             measured_voltage /\
             modeled_voltage_with_snow_copy

--- a/pvanalytics/features/snow.py
+++ b/pvanalytics/features/snow.py
@@ -224,7 +224,7 @@ def categorize(transmission, measured_voltage,
     modeled_voltage_with_snow_copy = np.where(
         transmission == 0, 0, modeled_voltage_with_snow)
 
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore',invalid='ignore'):
         vmp_ratio =\
             measured_voltage /\
             modeled_voltage_with_snow_copy

--- a/pvanalytics/quality/outliers.py
+++ b/pvanalytics/quality/outliers.py
@@ -1,5 +1,6 @@
 """Functions for identifying and labeling outliers."""
 import pandas as pd
+import numpy as np
 from scipy import stats
 from statsmodels import robust
 
@@ -75,7 +76,8 @@ def zscore(data, zmax=1.5, nan_policy='raise'):
                              "nan_policy. Expected 'raise' or 'omit'.")
 
     is_outlier = pd.Series(False, index=data.index)
-    is_outlier.loc[~nan_mask] = abs(stats.zscore(data[~nan_mask])) > zmax
+    with np.errstate(invalid='ignore'):
+        is_outlier.loc[~nan_mask] = abs(stats.zscore(data[~nan_mask])) > zmax
     return is_outlier
 
 

--- a/pvanalytics/util/_fit.py
+++ b/pvanalytics/util/_fit.py
@@ -127,4 +127,7 @@ def quartic_restricted_r2(x, y, noon=720):
     )
     model = _quartic(x, params[0], params[1], params[2], params[3])
     residuals = y - model
-    return 1 - (np.sum(residuals**2) / np.sum((y - np.mean(y))**2))
+    ss_tot = np.sum((y - np.mean(y))**2)
+    if ss_tot == 0:
+        return 0.0
+    return 1 - (np.sum(residuals**2) / ss_tot)


### PR DESCRIPTION
Closes #237 

## Description
Two functions emitted `RuntimeWarning` for valid edge-case inputs:
**1. `snow.py:229`** —> `invalid value encountered in divide` when `modeled_voltage_with_snow_copy` contains zeros. The existing `np.errstate(divide='ignore')` did not cover the `invalid` case (`0/0`). Added `invalid='ignore'` to the existing errstate.

**2. `outliers.py:78`** —> `Precision loss` RuntimeWarning from `scipy.stats.zscore` when all input values are identical. Wrapped the zscore call with `np.errstate(invalid='ignore')`.
<!-- Thank you for your contribution! Please don't hesitate to ask for help if you are unsure of how to accomplish any of the items. 
You are free to strikethrough any checklist items that do not apply or to add additional items that are not on this list. -->

- [ ] Closes #237 
- [ ] Added tests to cover all new or modified code.
- [ ] Non-API functions clearly documented with docstrings or comments as necessary.
- [ ] Adds description and name entries in the appropriate "what's new" file 
      in [`docs/whatsnew`](https://github.com/pvlib/pvanalytics/tree/main/docs/whatsnew) 
      for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` 
      or this Pull Request with `` :pull:`num` ``. Includes contributor name 
      and/or GitHub username (link with `` :ghuser:`user` ``).
- [ ] Pull request is nearly complete and ready for detailed review.
- [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Please provide a brief description of the problem and the proposed solution or new feature (if not already fully described in a linked issue): -->
